### PR TITLE
One-click deployment optimization

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -423,6 +423,8 @@ APPJOINTNAME=visualis
 #visualis  appjoint install
 installAppjoints
 echo "<----------------$APPJOINTNAME:end------------------->"
+##sample version does not install qualitis APPJoint and scheduis APPJoint
+if [[ '2' = "$INSTALL_MODE" ]];then
 echo ""
 echo "<----------------qualitis  appjoint install start------------------->"
 APPJOINTPARENT=dss-appjoints
@@ -441,3 +443,4 @@ APPJOINTNAME=schedulis
 installAppjoints
 isSuccess "subsitution conf of qualitis"
 echo "<----------------$APPJOINTNAME:end------------------->"
+fi


### PR DESCRIPTION
1.The execution directory is separated from the installation directory.
2.The default path of visualis-server's yml file frontEnd is wrong.
3.Simple version does not install qualitis and azkaban by default.
close #13
