### PR TITLE
fix editor version bug

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -35,7 +35,7 @@
         "md5": "^2.2.1",
         "mitt": "^1.1.3",
         "moment": "^2.22.2",
-        "monaco-editor": "^0.15.1",
+        "monaco-editor": "^0.20.0",
         "pinyin": "^2.9.0",
         "qs": "^6.9.1",
         "reconnecting-websocket": "^4.1.10",

--- a/web/src/js/component/editor/editor.vue
+++ b/web/src/js/component/editor/editor.vue
@@ -91,7 +91,7 @@ export default {
         if (newValue == this.getValue()) {
           return;
         }
-        let readOnly = this.editor.getConfiguration().readOnly;
+        let readOnly = this.editor.getRawOptions().readOnly;
         if (readOnly) {
           // editor.setValue 和 model.setValue 都会丢失撤销栈
           this.editor.setValue(newValue);


### PR DESCRIPTION
fix editor version bug ,  monaco-editor  * `getConfiguration()` is replaced by `getRawOptions()`, which returns the passed in editor options.

Issue #113 
fixed #113 