### PR TITLE
Update index.vue

### DIFF
--- a/web/src/js/module/process/index.vue
+++ b/web/src/js/module/process/index.vue
@@ -53,7 +53,7 @@
           <Ide
             v-if="item.type === 'IDE'"
             v-show="index===active"
-            :key="index"
+            :key="'IDE'+item.key"
             :parameters="item.data"
             :node="item.node"
             :in-flows-index="index"


### PR DESCRIPTION
修复工作流中，同时打开多个脚步后，从前完后关闭脚步后，前面文本会覆盖掉后面打开脚步的bug