### PR TITLE
Add dss-standard module, which is three kind of basic request protocol to integrate with upper-layer application systems.

### DIFF
--- a/dss-standard/development-standard/development-process-standard-execution/pom.xml
+++ b/dss-standard/development-standard/development-process-standard-execution/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>dss</artifactId>
+    <groupId>com.webank.wedatasphere.dss</groupId>
+    <version>1.0.0</version>
+    <relativePath>../../../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>dss-development-process-standard-execution</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.webank.wedatasphere.dss</groupId>
+      <artifactId>dss-development-process-standard</artifactId>
+      <version>${dss.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.webank.wedatasphere.dss</groupId>
+      <artifactId>dss-common</artifactId>
+      <version>${dss.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/async/RefExecutionListener.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/async/RefExecutionListener.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.async;
+
+
+public interface RefExecutionListener {
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/async/RefExecutionResponseListener.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/async/RefExecutionResponseListener.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.async;
+
+import com.webank.wedatasphere.dss.standard.app.development.listener.common.CompletedExecutionResponseRef;
+
+
+public interface RefExecutionResponseListener extends RefExecutionListener {
+
+    void onRefExecutionCompleted(CompletedExecutionResponseRef response);
+
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/async/RefExecutionStatusListener.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/async/RefExecutionStatusListener.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.async;
+
+import com.webank.wedatasphere.dss.standard.app.development.ref.ExecutionRequestRef;
+import com.webank.wedatasphere.dss.standard.app.development.listener.common.AsyncExecutionResponseRef;
+import com.webank.wedatasphere.dss.standard.app.development.listener.common.CompletedExecutionResponseRef;
+import com.webank.wedatasphere.dss.standard.app.development.listener.common.RefExecutionAction;
+
+
+public interface RefExecutionStatusListener extends RefExecutionListener {
+
+    void beforeSubmit(ExecutionRequestRef requestRef);
+
+    void afterSubmit(ExecutionRequestRef requestRef, RefExecutionAction action);
+
+    void afterAsyncResponseRef(AsyncExecutionResponseRef response);
+
+    void afterCompletedExecutionResponseRef(ExecutionRequestRef requestRef, RefExecutionAction action,
+        CompletedExecutionResponseRef response);
+
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/common/AbstractRefExecutionAction.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/common/AbstractRefExecutionAction.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.common;
+
+import com.webank.wedatasphere.dss.standard.app.development.listener.core.ExecutionRequestRefContext;
+
+
+public abstract class AbstractRefExecutionAction implements RefExecutionAction {
+
+    private String id;
+    private ExecutionRequestRefContext executionRequestRefContext;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public boolean isKilledFlag() {
+        return killedFlag;
+    }
+
+    public void setKilledFlag(boolean killedFlag) {
+        this.killedFlag = killedFlag;
+    }
+
+    private boolean killedFlag = false;
+
+    @Override
+    public ExecutionRequestRefContext getExecutionRequestRefContext() {
+        return executionRequestRefContext;
+    }
+
+    public void setExecutionRequestRefContext(ExecutionRequestRefContext executionRequestRefContext) {
+        this.executionRequestRefContext = executionRequestRefContext;
+    }
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/common/AsyncExecutionRequestRef.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/common/AsyncExecutionRequestRef.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.common;
+
+import com.webank.wedatasphere.dss.standard.app.development.ref.ExecutionRequestRef;
+import com.webank.wedatasphere.dss.standard.app.development.listener.core.ExecutionRequestRefContext;
+import java.util.Map;
+
+
+public interface AsyncExecutionRequestRef extends ExecutionRequestRef {
+
+    ExecutionRequestRefContext getExecutionRequestRefContext();
+
+    void setExecutionRequestRefContext(ExecutionRequestRefContext executionRequestRefContext);
+
+    void setProjectName(String projectName);
+
+    void setOrchestratorName(String orchestratorName);
+
+    void setJobContent(Map<String, Object> jobContent);
+
+    void setName(String name);
+
+    void setType(String type);
+
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/common/AsyncExecutionResponseRef.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/common/AsyncExecutionResponseRef.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.common;
+
+import com.webank.wedatasphere.dss.standard.app.development.ref.ExecutionRequestRef;
+import com.webank.wedatasphere.dss.standard.app.development.listener.async.RefExecutionResponseListener;
+import com.webank.wedatasphere.dss.standard.app.development.listener.core.LongTermRefExecutionOperation;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+
+
+public interface AsyncExecutionResponseRef extends ResponseRef {
+
+    RefExecutionAction getAction();
+
+    void setAction(RefExecutionAction action);
+
+    void addListener(RefExecutionResponseListener listener);
+
+    void setExecutionRequestRef(ExecutionRequestRef requestRef);
+
+    ExecutionRequestRef getExecutionRequestRef();
+
+    LongTermRefExecutionOperation getRefExecution();
+
+    void setRefExecution(LongTermRefExecutionOperation refExecution);
+
+    long getAskStatePeriod();
+
+    void setAskStatePeriod(long askStatePeriod);
+
+    void setCompleted(CompletedExecutionResponseRef response);
+
+    boolean isCompleted();
+
+    long getStartTime();
+
+    long getMaxLoopTime();
+
+    void setMaxLoopTime(long maxLoopTime);
+
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/common/AsyncResponseRefImpl.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/common/AsyncResponseRefImpl.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.common;
+
+import com.webank.wedatasphere.dss.standard.app.development.ref.ExecutionRequestRef;
+import com.webank.wedatasphere.dss.standard.app.development.listener.async.RefExecutionResponseListener;
+import com.webank.wedatasphere.dss.standard.app.development.listener.core.LongTermRefExecutionOperation;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.AbstractResponseRef;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.AsyncResponseRef;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+
+public class AsyncResponseRefImpl extends AbstractResponseRef implements AsyncResponseRef, AsyncExecutionResponseRef {
+
+    private RefExecutionAction action;
+    private ExecutionRequestRef requestRef;
+    private LongTermRefExecutionOperation refExecution;
+    private boolean isCompleted = false;
+    private CompletedExecutionResponseRef response;
+    private long startTime = System.currentTimeMillis();
+    private long askStatePeriod = 1000;
+    private long maxLoopTime = -1;
+    private final Object lock = new Object();
+
+    /**
+     * 通过监听的方式，任务一旦完成，我们就通知上层
+     */
+    private List<RefExecutionResponseListener> listeners = new ArrayList<>();
+
+    public AsyncResponseRefImpl(String responseBody, int status) {
+        super(responseBody, status);
+    }
+
+    public AsyncResponseRefImpl() {
+        super(null, -1);
+    }
+
+    @Override
+    public RefExecutionAction getAction() {
+        return action;
+    }
+
+    @Override
+    public void setAction(RefExecutionAction action) {
+        this.action = action;
+    }
+
+    @Override
+    public void addListener(RefExecutionResponseListener listener) {
+        this.listeners.add(listener);
+    }
+
+    @Override
+    public void setExecutionRequestRef(ExecutionRequestRef requestRef) {
+        this.requestRef = requestRef;
+    }
+
+    @Override
+    public ExecutionRequestRef getExecutionRequestRef() {
+        return requestRef;
+    }
+
+    @Override
+    public LongTermRefExecutionOperation getRefExecution() {
+        return refExecution;
+    }
+
+    @Override
+    public void setRefExecution(LongTermRefExecutionOperation refExecution) {
+        this.refExecution = refExecution;
+    }
+
+    @Override
+    public long getAskStatePeriod() {
+        return askStatePeriod;
+    }
+
+    @Override
+    public void setAskStatePeriod(long askStatePeriod) {
+        this.askStatePeriod = askStatePeriod;
+    }
+
+    @Override
+    public boolean isCompleted() {
+        return isCompleted;
+    }
+
+    @Override
+    public ResponseRef getResponse() {
+        return response;
+    }
+
+    @Override
+    public void waitForCompleted() throws InterruptedException {
+        synchronized (lock) {
+            while(!isCompleted) {
+                lock.wait(2000);
+            }
+        }
+    }
+
+    @Override
+    public void notifyMe(Consumer<ResponseRef> notifyListener) {
+        addListener(response -> notifyListener.accept(response));
+    }
+
+    @Override
+    public void setCompleted(CompletedExecutionResponseRef response) {
+        isCompleted = true;
+        this.response = response;
+        status = response.getStatus();
+        responseBody = response.getResponseBody();
+        synchronized (lock) {
+            lock.notifyAll();
+        }
+        listeners.forEach(l -> l.onRefExecutionCompleted(response));
+    }
+
+    @Override
+    public long getMaxLoopTime() {
+        return maxLoopTime;
+    }
+
+    @Override
+    public void setMaxLoopTime(long maxLoopTime) {
+        this.maxLoopTime = maxLoopTime;
+    }
+
+    @Override
+    public long getStartTime() {
+        return startTime;
+    }
+
+    @Override
+    public Map<String, Object> toMap() {
+        if(response != null) {
+            return response.toMap();
+        }
+        return null;
+    }
+
+    @Override
+    public String getErrorMsg() {
+        if(response != null) {
+            return response.getErrorMsg();
+        }
+        return null;
+    }
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/common/CompletedExecutionResponseRef.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/common/CompletedExecutionResponseRef.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.common;
+
+import com.webank.wedatasphere.dss.standard.common.entity.ref.AbstractResponseRef;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class CompletedExecutionResponseRef extends AbstractResponseRef {
+
+    private Throwable exception;
+
+    public CompletedExecutionResponseRef(int status) {
+        super(null, status);
+    }
+
+    public CompletedExecutionResponseRef(String responseBody, int status) {
+        super(responseBody, status);
+    }
+
+    public void setIsSucceed(boolean isSucceed) {
+        if(isSucceed) {
+            status = 200;
+        } else {
+            status = 400;
+        }
+    }
+
+    public void setErrorMsg(String errorMsg) {
+        this.errorMsg = errorMsg;
+    }
+
+    @Override
+    public String getErrorMsg() {
+        return errorMsg;
+    }
+
+    public Throwable getException() {
+        return exception;
+    }
+
+    public void setException(Throwable exception) {
+        this.exception = exception;
+    }
+
+    @Override
+    public Map<String, Object> toMap() {
+        if(responseMap == null || (Integer) responseMap.get("status") == -1) {
+            responseMap = new HashMap<>(3);
+            responseMap.put("errorMsg", errorMsg);
+            responseMap.put("status", status);
+            responseMap.put("exception", exception);
+        }
+        return responseMap;
+    }
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/common/LongTermRefExecutionAction.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/common/LongTermRefExecutionAction.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.common;
+
+
+public interface LongTermRefExecutionAction extends RefExecutionAction {
+
+    void setSchedulerId(int schedulerId);
+
+    int getSchedulerId();
+
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/common/RefExecutionAction.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/common/RefExecutionAction.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.common;
+
+import com.webank.wedatasphere.dss.standard.app.development.listener.core.ExecutionRequestRefContext;
+
+
+public interface RefExecutionAction {
+
+    ExecutionRequestRefContext getExecutionRequestRefContext();
+
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/common/RefExecutionState.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/common/RefExecutionState.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.common;
+
+
+public enum RefExecutionState {
+    /**
+     * NodeExecution的状态枚举
+     */
+    Accepted(0, "Accepted"),
+    Running(1, "Running"),
+    Success(2, "Success"),
+    Failed(3, "Failed"),
+    Killed(4, "Killed"),
+    Alert(5, "Alert");
+
+    private int code;
+    private String status;
+
+    private RefExecutionState(int code, String status){
+        this.code = code;
+        this.status = status;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public static boolean isCompleted(RefExecutionState state){
+        return Success.equals(state) || Failed.equals(state) || Killed.equals(state);
+    }
+
+    public static boolean isCompleted(String state){
+        return Success.status.equals(state) ||
+                Failed.status.equals(state) ||
+                Killed.status.equals(state);
+    }
+
+    public boolean isCompleted(){
+        return isCompleted(this);
+    }
+
+    public boolean isSuccess(){
+        return Success.equals(this);
+    }
+
+
+
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/core/CallbackLongTermRefExecutionOperation.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/core/CallbackLongTermRefExecutionOperation.java
@@ -1,0 +1,53 @@
+
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.core;
+
+import com.webank.wedatasphere.dss.standard.app.development.ref.ExecutionRequestRef;
+import com.webank.wedatasphere.dss.standard.app.development.listener.common.AsyncExecutionResponseRef;
+import com.webank.wedatasphere.dss.standard.app.development.listener.common.CompletedExecutionResponseRef;
+import com.webank.wedatasphere.dss.standard.app.development.listener.common.RefExecutionAction;
+import com.webank.wedatasphere.dss.standard.app.development.listener.conf.RefExecutionConfiguration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+
+public abstract class CallbackLongTermRefExecutionOperation extends LongTermRefExecutionOperation {
+
+    protected Map<RefExecutionAction, AsyncExecutionResponseRef> asyncResponses = new ConcurrentHashMap<RefExecutionAction, AsyncExecutionResponseRef>();
+
+    public String getCallbackURL(ExecutionRequestRefContext executionRequestRefContext){
+        String urlSuffix = RefExecutionConfiguration.CALL_BACK_URL().getValue();
+        return executionRequestRefContext.getGatewayUrl() + urlSuffix;
+    }
+
+    public abstract void acceptCallback(Map<String, Object> callbackMap);
+
+    protected void markCompleted(RefExecutionAction action, CompletedExecutionResponseRef resultResponse) {
+        AsyncExecutionResponseRef response = asyncResponses.get(action);
+        asyncResponses.remove(action);
+        response.setCompleted(resultResponse);
+    }
+
+    @Override
+    protected AsyncExecutionResponseRef createAsyncResponseRef(ExecutionRequestRef requestRef, RefExecutionAction action) {
+        AsyncExecutionResponseRef response = super.createAsyncResponseRef(requestRef, action);
+        response.setAskStatePeriod(RefExecutionConfiguration.CALLBACK_REF_EXECUTION_REFRESH_INTERVAL().getValue().toLong());
+        asyncResponses.put(action, response);
+        return response;
+    }
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/core/ExecutionRequestRefContext.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/core/ExecutionRequestRefContext.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.core;
+
+import com.webank.wedatasphere.linkis.common.io.FsPath;
+import com.webank.wedatasphere.linkis.common.io.MetaData;
+import com.webank.wedatasphere.linkis.common.io.Record;
+import com.webank.wedatasphere.linkis.common.io.resultset.ResultSet;
+import com.webank.wedatasphere.linkis.common.io.resultset.ResultSetReader;
+import com.webank.wedatasphere.linkis.common.io.resultset.ResultSetWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public interface ExecutionRequestRefContext {
+
+
+    static final String TOKEN_USER_STR = "Token-User";
+
+    static final String TOKEN_CODE_STR = "Token-Code";
+
+
+    public Map<String, Object> getRuntimeMap();
+
+    public void appendLog(String log);
+
+    public void updateProgress(float progress);
+
+    LinkisJob fetchLinkisJob(long jobId);
+
+    //获取任务的所有的结果集路径
+    FsPath[] fetchLinkisJobResultSetPaths(long jobId);
+
+    /**
+     * 获取本节点的操作用户
+     * @return
+     */
+    public String getUser();
+
+    void setStorePath(String storePath);
+
+    String getStorePath();
+
+    <M extends MetaData, R extends Record> ResultSetWriter<M, R> createTableResultSetWriter();
+
+    <M extends MetaData, R extends Record> ResultSetWriter<M, R> createTableResultSetWriter(String resultSetAlias);
+
+    <M extends MetaData, R extends Record> ResultSetWriter<M, R> createTextResultSetWriter();
+
+    <M extends MetaData, R extends Record> ResultSetWriter<M, R> createTextResultSetWriter(String resultSetAlias);
+
+    <M extends MetaData, R extends Record> ResultSetWriter<M, R> createHTMLResultSetWriter();
+
+    <M extends MetaData, R extends Record> ResultSetWriter<M, R> createHTMLResultSetWriter(String resultSetAlias);
+
+    <M extends MetaData, R extends Record> ResultSetWriter<M, R> createPictureResultSetWriter();
+
+    <M extends MetaData, R extends Record> ResultSetWriter<M, R> createPictureResultSetWriter(String resultSetAlias);
+
+    <M extends MetaData, R extends Record> ResultSetWriter<M, R> createResultSetWriter(ResultSet<? extends MetaData, ? extends Record> resultSet,
+        String resultSetAlias);
+
+
+    <M extends MetaData, R extends Record> ResultSetReader<M, R> getResultSetReader(FsPath fsPath);
+
+    void sendResultSet(ResultSetWriter<? extends MetaData, ? extends Record> resultSetWriter);
+
+    /**
+     *
+     * @return
+     */
+    String getGatewayUrl();
+
+
+    default Map<String,String> getTokenHeader(String user){
+        Map<String, String> tokenHeader = new HashMap<>();
+        tokenHeader.put(TOKEN_CODE_STR, "dss-AUTH");
+        tokenHeader.put(TOKEN_USER_STR, user);
+        return tokenHeader;
+    }
+
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/core/HttpLongTermRefExecution.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/core/HttpLongTermRefExecution.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.core;
+
+
+public abstract class HttpLongTermRefExecution extends LongTermRefExecutionOperation {
+
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/core/Killable.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/core/Killable.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.core;
+
+
+import com.webank.wedatasphere.dss.standard.app.development.listener.common.RefExecutionAction;
+
+
+public interface Killable {
+    public boolean kill(RefExecutionAction action);
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/core/LinkisJob.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/core/LinkisJob.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.core;
+
+import com.webank.wedatasphere.linkis.manager.label.entity.Label;
+import java.util.List;
+import java.util.Map;
+
+
+public interface LinkisJob {
+
+    String getResultLocation();
+
+    String getSubmitUser();
+
+    String getExecuteUser();
+
+    String getStatus();
+
+    Map<String, String> getSource();
+
+    Map<String, Object> getParams();
+
+    List<Label<?>> getLabels();
+
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/core/LongTermRefExecutionOperation.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/core/LongTermRefExecutionOperation.java
@@ -35,7 +35,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Description: LongTermRefExecutionOperation 是一个
+ * Description: LongTermRefExecutionOperation is used to execute long-term tasks in external application systems.
+ * Long-term task usually supports to execute asyncly and can fetch status and logs when it is submitted.
+ *
  */
 public abstract class LongTermRefExecutionOperation implements RefExecutionOperation {
 

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/core/LongTermRefExecutionOperation.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/core/LongTermRefExecutionOperation.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.core;
+
+import com.webank.wedatasphere.dss.standard.app.development.ref.ExecutionRequestRef;
+import com.webank.wedatasphere.dss.standard.app.development.operation.RefExecutionOperation;
+import com.webank.wedatasphere.dss.standard.app.development.listener.async.RefExecutionStatusListener;
+import com.webank.wedatasphere.dss.standard.app.development.listener.common.AbstractRefExecutionAction;
+import com.webank.wedatasphere.dss.standard.app.development.listener.common.AsyncExecutionRequestRef;
+import com.webank.wedatasphere.dss.standard.app.development.listener.common.AsyncExecutionResponseRef;
+import com.webank.wedatasphere.dss.standard.app.development.listener.common.AsyncResponseRefImpl;
+import com.webank.wedatasphere.dss.standard.app.development.listener.common.CompletedExecutionResponseRef;
+import com.webank.wedatasphere.dss.standard.app.development.listener.common.RefExecutionAction;
+import com.webank.wedatasphere.dss.standard.app.development.listener.common.RefExecutionState;
+import com.webank.wedatasphere.dss.standard.app.development.listener.exception.AppConnExecutionWarnException;
+import com.webank.wedatasphere.dss.standard.app.development.listener.scheduler.LongTermRefExecutionScheduler;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Description: LongTermRefExecutionOperation 是一个
+ */
+public abstract class LongTermRefExecutionOperation implements RefExecutionOperation {
+
+    private static final Logger logger = LoggerFactory.getLogger(LongTermRefExecutionOperation.class);
+
+    private List<RefExecutionStatusListener> refExecutionListener = new ArrayList<RefExecutionStatusListener>();
+    private LongTermRefExecutionScheduler scheduler = SchedulerManager.getScheduler();
+
+    public void addRefExecutionStatusListener(RefExecutionStatusListener refExecutionListener) {
+        for(RefExecutionStatusListener listener : this.refExecutionListener){
+            if (listener.getClass().equals(refExecutionListener.getClass())){
+                return;
+            }
+        }
+        this.refExecutionListener.add(refExecutionListener);
+    }
+
+    public LongTermRefExecutionScheduler getScheduler() {
+        return scheduler;
+    }
+
+    public void setScheduler(LongTermRefExecutionScheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    protected abstract RefExecutionAction submit(ExecutionRequestRef requestRef);
+
+    public abstract RefExecutionState state(RefExecutionAction action);
+
+    public abstract CompletedExecutionResponseRef result(RefExecutionAction action);
+
+
+    protected ExecutionRequestRefContext createExecutionRequestRefContext(ExecutionRequestRef requestRef) {
+        if(requestRef instanceof AsyncExecutionRequestRef) {
+            return ((AsyncExecutionRequestRef) requestRef).getExecutionRequestRefContext();
+        } else {
+            throw new AppConnExecutionWarnException(75536, "Cannot find a available ExecutionRequestRefContext.");
+        }
+    }
+
+    @Override
+    public ResponseRef execute(ExecutionRequestRef requestRef) {
+        refExecutionListener.forEach(l -> l.beforeSubmit(requestRef));
+        RefExecutionAction action = submit(requestRef);
+        if(action instanceof AbstractRefExecutionAction) {
+            ((AbstractRefExecutionAction) action).setExecutionRequestRefContext(createExecutionRequestRefContext(requestRef));
+        }
+        refExecutionListener.forEach(l -> l.afterSubmit(requestRef, action));
+        RefExecutionState state = state(action);
+        if(state != null && state.isCompleted()) {
+            CompletedExecutionResponseRef response = result(action);
+            refExecutionListener.forEach(l -> l.afterCompletedExecutionResponseRef(requestRef, action, response));
+            return response;
+        } else {
+            AsyncExecutionResponseRef response = createAsyncResponseRef(requestRef, action);
+            response.setRefExecution(this);
+            refExecutionListener.forEach(l -> l.afterAsyncResponseRef(response));
+            response.addListener(r -> refExecutionListener.forEach(l -> l.afterCompletedExecutionResponseRef(requestRef, action, (CompletedExecutionResponseRef) r)));
+            if(scheduler != null) {
+                scheduler.addAsyncResponse(response);
+            }
+            return response;
+        }
+    }
+
+    protected AsyncExecutionResponseRef createAsyncResponseRef(ExecutionRequestRef requestRef, RefExecutionAction action) {
+        AsyncResponseRefImpl response =  new AsyncResponseRefImpl();
+        response.setAction(action);
+        response.setExecutionRequestRef(requestRef);
+        return response;
+    }
+
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/core/ParamsNode.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/core/ParamsNode.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.core;
+
+import java.util.Map;
+
+
+public interface ParamsNode {
+    public Map<String, Object> getParams();
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/core/Procedure.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/core/Procedure.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.core;
+
+
+import com.webank.wedatasphere.dss.standard.app.development.listener.common.RefExecutionAction;
+
+
+public interface Procedure {
+
+    public float progress(RefExecutionAction action);
+
+    public String log(RefExecutionAction action);
+
+
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/core/SchedulerManager.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/core/SchedulerManager.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.core;
+
+import com.webank.wedatasphere.dss.standard.app.development.listener.scheduler.ListenerEventBusRefExecutionScheduler;
+import com.webank.wedatasphere.dss.standard.app.development.listener.scheduler.LongTermRefExecutionScheduler;
+
+
+public class SchedulerManager {
+
+    private static LongTermRefExecutionScheduler scheduler = new ListenerEventBusRefExecutionScheduler();
+
+    static{
+        ((ListenerEventBusRefExecutionScheduler)scheduler).start();
+    }
+
+    public static LongTermRefExecutionScheduler getScheduler(){
+        return scheduler;
+    }
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/exception/AppConnExecutionErrorException.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/exception/AppConnExecutionErrorException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.exception;
+
+import com.webank.wedatasphere.linkis.common.exception.ErrorException;
+
+
+public class AppConnExecutionErrorException extends ErrorException {
+
+    public AppConnExecutionErrorException(int errCode, String desc) {
+        super(errCode, desc);
+    }
+
+    public AppConnExecutionErrorException(int errCode, String desc, Throwable cause) {
+        super(errCode, desc);
+        initCause(cause);
+    }
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/exception/AppConnExecutionWarnException.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/exception/AppConnExecutionWarnException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.exception;
+
+import com.webank.wedatasphere.linkis.common.exception.WarnException;
+
+
+public class AppConnExecutionWarnException extends WarnException {
+
+    public AppConnExecutionWarnException(int errCode, String desc) {
+        super(errCode, desc);
+    }
+
+    public AppConnExecutionWarnException(int errCode, String desc, Throwable cause) {
+        super(errCode, desc);
+        initCause(cause);
+    }
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/scheduler/AsyncRefExecutionSchedulerListener.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/scheduler/AsyncRefExecutionSchedulerListener.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.scheduler;
+
+import com.webank.wedatasphere.linkis.common.listener.Event;
+import com.webank.wedatasphere.linkis.common.listener.EventListener;
+
+
+public interface AsyncRefExecutionSchedulerListener extends EventListener {
+
+    void onEvent(AsyncResponseRefEvent event);
+
+    void onEventError(AsyncResponseRefEvent event, Throwable t);
+
+    @Override
+    default void onEventError(Event event, Throwable t) {
+        if(event instanceof AsyncResponseRefEvent) {
+            onEventError((AsyncResponseRefEvent) event, t);
+        }
+    }
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/scheduler/AsyncResponseRefEvent.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/scheduler/AsyncResponseRefEvent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.scheduler;
+
+import com.webank.wedatasphere.dss.standard.app.development.listener.common.AsyncExecutionResponseRef;
+import com.webank.wedatasphere.linkis.common.listener.Event;
+
+
+public class AsyncResponseRefEvent implements Event {
+
+    private AsyncExecutionResponseRef response;
+    private long lastAskTime = 0;
+
+    public AsyncResponseRefEvent(AsyncExecutionResponseRef response) {
+        this.response = response;
+    }
+
+    public AsyncExecutionResponseRef getResponse() {
+        return response;
+    }
+
+    public void setResponse(AsyncExecutionResponseRef response) {
+        this.response = response;
+    }
+
+    public long getLastAskTime() {
+        return lastAskTime;
+    }
+
+    public void setLastAskTime() {
+        this.lastAskTime = System.currentTimeMillis();
+    }
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/scheduler/LongTermRefExecutionScheduler.java
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/scheduler/LongTermRefExecutionScheduler.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.scheduler;
+
+import com.webank.wedatasphere.dss.standard.app.development.listener.common.AsyncExecutionResponseRef;
+import com.webank.wedatasphere.dss.standard.app.development.listener.common.LongTermRefExecutionAction;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.AsyncResponseRef;
+
+
+public interface LongTermRefExecutionScheduler {
+
+    void addAsyncResponse(AsyncExecutionResponseRef response);
+
+    void removeAsyncResponse(LongTermRefExecutionAction action);
+
+    AsyncResponseRef getAsyncResponse(LongTermRefExecutionAction action);
+
+    void start();
+
+    void stop();
+
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/scala/com/webank/wedatasphere/dss/standard/app/development/listener/conf/RefExecutionConfiguration.scala
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/scala/com/webank/wedatasphere/dss/standard/app/development/listener/conf/RefExecutionConfiguration.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.conf
+
+import com.webank.wedatasphere.linkis.common.conf.{CommonVars, TimeType}
+
+
+object RefExecutionConfiguration {
+
+  val JOB_HISTORY_APPLICATION_NAME = CommonVars("wds.dss.appconn.jobhistory.service.name", "linkis-ps-publicservice")
+  val CALL_BACK_URL = CommonVars("wds.dss.appconn.ref-execution.callback.url", "/api/rest_j/v1/engineconn/callback")
+
+  val ASYNC_REF_EXECUTION_SCHEDULER_QUEUE_SIZE = CommonVars("wds.dss.appconn.ref-execution.scheduler.queue.size", 2000)
+  val ASYNC_REF_EXECUTION_SCHEDULER_THREAD_SIZE = CommonVars("wds.dss.appconn.ref-execution.scheduler.thread.max", 20)
+
+  val CALLBACK_REF_EXECUTION_REFRESH_INTERVAL = CommonVars("wds.dss.appconn.ref-execution.callback.refresh.interval", new TimeType("2m"))
+
+}

--- a/dss-standard/development-standard/development-process-standard-execution/src/main/scala/com/webank/wedatasphere/dss/standard/app/development/listener/scheduler/ListenerEventBusRefExecutionScheduler.scala
+++ b/dss-standard/development-standard/development-process-standard-execution/src/main/scala/com/webank/wedatasphere/dss/standard/app/development/listener/scheduler/ListenerEventBusRefExecutionScheduler.scala
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener.scheduler
+
+import java.util
+import java.util.concurrent.ArrayBlockingQueue
+
+import com.webank.wedatasphere.dss.standard.app.development.listener.common.{AbstractRefExecutionAction, AsyncExecutionResponseRef, AsyncResponseRefImpl, CompletedExecutionResponseRef, LongTermRefExecutionAction}
+import com.webank.wedatasphere.dss.standard.app.development.listener.conf.RefExecutionConfiguration._
+import com.webank.wedatasphere.dss.standard.app.development.listener.exception.AppConnExecutionErrorException
+import com.webank.wedatasphere.linkis.common.listener.ListenerEventBus
+import com.webank.wedatasphere.linkis.common.utils.{ByteTimeUtils, Utils}
+import org.apache.commons.lang.exception.ExceptionUtils
+import org.apache.commons.lang.time.DateFormatUtils
+
+
+class ListenerEventBusRefExecutionScheduler(eventQueueCapacity: Int, name: String)(listenerConsumerThreadSize: Int)
+  extends LongTermRefExecutionScheduler {
+
+  private val listenerEventBus = new ListenerEventBus[AsyncRefExecutionSchedulerListener, AsyncResponseRefEvent](eventQueueCapacity, name)(listenerConsumerThreadSize) {
+    override protected val dropEvent: DropEvent = new DropEvent {
+      override def onDropEvent(event: AsyncResponseRefEvent): Unit = throw new AppConnExecutionErrorException(95536, "LongTermNodeExecutionScheduler is full, please ask admin for help!")
+      override def onBusStopped(event: AsyncResponseRefEvent): Unit = throw new AppConnExecutionErrorException(95536, "LongTermNodeExecutionScheduler is stopped, please ask admin for help!")
+    }
+    override def doPostEvent(listener: AsyncRefExecutionSchedulerListener, event: AsyncResponseRefEvent): Unit = {
+      listener.onEvent(event)
+    }
+  }
+
+  def this() = {
+    this(ASYNC_REF_EXECUTION_SCHEDULER_QUEUE_SIZE.getValue, "Async-NodeExecution-Scheduler")(ASYNC_REF_EXECUTION_SCHEDULER_THREAD_SIZE.getValue)
+    getAsyncRefExecutionSchedulerListeners.foreach(listenerEventBus.addListener)
+  }
+
+  private val eventQueue = {
+    val ru = scala.reflect.runtime.universe
+    val classMirror = ru.runtimeMirror(getClass.getClassLoader)
+    val listenerEventBusClass = classMirror.reflect(listenerEventBus)
+    val field1 = ru.typeOf[ListenerEventBus[_, _]].decl(ru.TermName("eventQueue")).asMethod
+    val result = listenerEventBusClass.reflectMethod(field1)
+    result() match {
+      case queue: ArrayBlockingQueue[AsyncResponseRefEvent] => queue
+    }
+  }
+
+  protected def getAsyncRefExecutionSchedulerListeners: Array[AsyncRefExecutionSchedulerListener] = {
+    Array(new AsyncRefExecutionSchedulerListener() {
+      override def onEvent(event: AsyncResponseRefEvent): Unit = if(!event.getResponse.isCompleted) {
+        val response = event.getResponse
+        val action = response.getAction.asInstanceOf[AbstractRefExecutionAction]
+        if(action.isKilledFlag){
+          val resultResponse = response.getRefExecution.result(response.getAction)
+          onEventCompleted(event, resultResponse)
+        }
+        if(response.getMaxLoopTime > 0 && System.currentTimeMillis - response.getStartTime >= response.getMaxLoopTime) {
+          onEventError(event, new AppConnExecutionErrorException(75533, s"AppConnNode Execution is overtime! StartTime is ${DateFormatUtils.format(response.getStartTime, "yyyy-MM-dd HH:mm:ss")}, maxWaitTime is " +
+            ByteTimeUtils.msDurationToString(response.getMaxLoopTime)))
+          return
+        }
+        val period = System.currentTimeMillis() - event.getLastAskTime
+        if(period < response.getAskStatePeriod) {
+          if(period < 10) Utils.sleepQuietly(100)
+          if(!response.isCompleted) addEvent(event)
+          return
+        }
+        val state = response.getRefExecution.state(response.getAction)
+        if(state.isCompleted) {
+          val resultResponse = response.getRefExecution.result(response.getAction)
+          onEventCompleted(event, resultResponse)
+        } else if(!response.isCompleted) {
+          event.setLastAskTime()
+          addEvent(event)
+        }
+      }
+
+      private def onEventCompleted(event: AsyncResponseRefEvent, response: CompletedExecutionResponseRef): Unit = {
+        event.getResponse.setCompleted(response)
+      }
+
+      override def onEventError(event: AsyncResponseRefEvent, t: Throwable): Unit = t match {
+        case e: Exception =>
+          val response = new CompletedExecutionResponseRef(400) {
+            override def toMap: util.Map[String, AnyRef] = new util.HashMap[String, AnyRef]
+            override def getErrorMsg: String = ExceptionUtils.getRootCauseMessage(e)
+          }
+          onEventCompleted(event, response)
+      }
+    })
+  }
+
+  override def addAsyncResponse(response: AsyncExecutionResponseRef): Unit =
+    addEvent(new AsyncResponseRefEvent(response))
+
+  protected def addEvent(event: AsyncResponseRefEvent): Unit = synchronized {
+    listenerEventBus.post(event)
+//    event.getResponse.getAction match {
+//      case longTermAction: LongTermRefExecutionAction =>
+//        longTermAction.setSchedulerId(eventQueue.max)
+//      case _ =>
+//    }
+  }
+
+  override def removeAsyncResponse(action: LongTermRefExecutionAction): Unit = {
+
+  }
+
+  override def getAsyncResponse(action: LongTermRefExecutionAction): AsyncResponseRefImpl = null
+
+  override def start(): Unit = listenerEventBus.start()
+
+  override def stop(): Unit = listenerEventBus.stop()
+}

--- a/dss-standard/development-standard/development-process-standard/pom.xml
+++ b/dss-standard/development-standard/development-process-standard/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>dss</artifactId>
+    <groupId>com.webank.wedatasphere.dss</groupId>
+    <version>1.0.0</version>
+    <relativePath>../../../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>dss-development-process-standard</artifactId>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+    <dependency>
+      <groupId>com.webank.wedatasphere.linkis</groupId>
+      <artifactId>linkis-common</artifactId>
+      <version>${linkis.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.webank.wedatasphere.dss</groupId>
+      <artifactId>dss-sso-integration-standard</artifactId>
+      <version>${dss.version}</version>
+    </dependency>
+      <dependency>
+          <groupId>com.webank.wedatasphere.dss</groupId>
+          <artifactId>dss-common</artifactId>
+          <version>${dss.version}</version>
+          <scope>provided</scope>
+      </dependency>
+
+    </dependencies>
+
+</project>

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/ExecutionLogListener.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/ExecutionLogListener.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener;
+
+public interface ExecutionLogListener {
+
+    void onInfo(String log);
+    void onERROR(String log);
+    void onWarn(String log);
+    void onSystemInfo(String log);
+    void onSystemError(String log);
+    void onSystemWarn(String log);
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/ExecutionResultListener.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/listener/ExecutionResultListener.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.listener;
+
+import com.webank.wedatasphere.linkis.common.io.MetaData;
+import com.webank.wedatasphere.linkis.common.io.Record;
+
+public interface ExecutionResultListener {
+
+    void setResultSetType(String resultSetType);
+    void onResultMetaData(MetaData metaData);
+    void onResultSetRecord(Record record);
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/operation/DevelopmentOperation.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/operation/DevelopmentOperation.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.operation;
+
+
+
+import com.webank.wedatasphere.dss.standard.app.development.service.DevelopmentService;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.RequestRef;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+import com.webank.wedatasphere.dss.standard.common.service.Operation;
+
+public interface DevelopmentOperation<K extends RequestRef, V extends ResponseRef> extends Operation<K,V> {
+
+    void setDevelopmentService(DevelopmentService service);
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/operation/RefCopyOperation.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/operation/RefCopyOperation.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.operation;
+
+import com.webank.wedatasphere.dss.standard.app.development.ref.CopyRequestRef;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.RequestRef;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+import com.webank.wedatasphere.dss.standard.common.exception.operation.ExternalOperationFailedException;
+
+public interface RefCopyOperation<K extends CopyRequestRef>
+        extends DevelopmentOperation<CopyRequestRef, ResponseRef> {
+
+
+    ResponseRef copyRef(K requestRef) throws ExternalOperationFailedException;
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/operation/RefCreationOperation.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/operation/RefCreationOperation.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.operation;
+
+import com.webank.wedatasphere.dss.standard.app.development.ref.CreateRequestRef;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+import com.webank.wedatasphere.dss.standard.common.exception.operation.ExternalOperationFailedException;
+
+public interface RefCreationOperation<K extends CreateRequestRef> extends DevelopmentOperation<K,ResponseRef> {
+
+    ResponseRef createRef(K requestRef) throws ExternalOperationFailedException;
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/operation/RefDeletionOperation.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/operation/RefDeletionOperation.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.operation;
+
+import com.webank.wedatasphere.dss.standard.common.entity.ref.RequestRef;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+import com.webank.wedatasphere.dss.standard.common.exception.operation.ExternalOperationFailedException;
+
+public interface RefDeletionOperation<K extends RequestRef> extends DevelopmentOperation<K, ResponseRef> {
+
+    void deleteRef(K requestRef) throws ExternalOperationFailedException;
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/operation/RefExecutionOperation.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/operation/RefExecutionOperation.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.operation;
+
+import com.webank.wedatasphere.dss.standard.app.development.ref.ExecutionRequestRef;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.RequestRef;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+import com.webank.wedatasphere.dss.standard.common.exception.operation.ExternalOperationFailedException;
+
+public interface RefExecutionOperation
+        extends DevelopmentOperation<RequestRef, ResponseRef> {
+
+    ResponseRef execute(ExecutionRequestRef requestRef) throws ExternalOperationFailedException;
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/operation/RefExportOperation.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/operation/RefExportOperation.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.operation;
+
+import com.webank.wedatasphere.dss.standard.common.entity.ref.RequestRef;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+import com.webank.wedatasphere.dss.standard.common.exception.operation.ExternalOperationFailedException;
+
+public interface RefExportOperation<K extends RequestRef> extends DevelopmentOperation<K,ResponseRef> {
+
+    ResponseRef exportRef(K requestRef) throws ExternalOperationFailedException;
+
+}
+
+

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/operation/RefImportOperation.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/operation/RefImportOperation.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.operation;
+
+import com.webank.wedatasphere.dss.standard.common.entity.ref.RequestRef;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+import com.webank.wedatasphere.dss.standard.common.exception.operation.ExternalOperationFailedException;
+
+public interface RefImportOperation<K extends RequestRef> extends DevelopmentOperation<K, ResponseRef> {
+
+    ResponseRef importRef(K requestRef) throws ExternalOperationFailedException;
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/operation/RefQueryOperation.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/operation/RefQueryOperation.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.operation;
+
+import com.webank.wedatasphere.dss.standard.common.entity.ref.RequestRef;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+import com.webank.wedatasphere.dss.standard.common.exception.operation.ExternalOperationFailedException;
+
+
+public interface RefQueryOperation<K extends RequestRef>
+        extends DevelopmentOperation<K, ResponseRef> {
+
+    ResponseRef query(K requestRef) throws ExternalOperationFailedException;
+    
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/operation/RefUpdateOperation.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/operation/RefUpdateOperation.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.operation;
+
+import com.webank.wedatasphere.dss.standard.common.entity.ref.RequestRef;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+import com.webank.wedatasphere.dss.standard.common.exception.operation.ExternalOperationFailedException;
+
+public interface RefUpdateOperation<K extends RequestRef>
+        extends DevelopmentOperation<K, ResponseRef>  {
+
+    ResponseRef updateRef(K requestRef) throws ExternalOperationFailedException;
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/CommonRequestRef.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/CommonRequestRef.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.ref;
+
+import com.webank.wedatasphere.dss.common.label.DSSLabel;
+
+import java.util.List;
+
+
+public interface CommonRequestRef extends WorkspaceRequestRef {
+
+    void setUserName(String userName);
+
+    String getUserName();
+
+    void setProjectId(Long projectId);
+
+    Long getProjectId();
+
+    void setProjectName(String projectName);
+
+    String getProjectName();
+
+    void setOrcName(String orcName);
+
+    String getOrcName();
+
+    void setOrcId(Long orcId);
+
+    Long getOrcId();
+
+    void setName(String name);
+
+    void setWorkspaceName(String workspaceName);
+
+    String getWorkspaceName();
+
+
+    String getContextID();
+
+
+    void setContextID(String contextIDStr);
+
+    void setDSSLabels(List<DSSLabel> dssLabels);
+
+    @Override
+    List<DSSLabel> getDSSLabels();
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/CommonResponseRef.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/CommonResponseRef.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.ref;
+
+
+public class CommonResponseRef extends com.webank.wedatasphere.dss.standard.common.entity.ref.CommonResponseRef {
+
+    protected Long orcId;
+    protected String content;
+    protected String name;
+    protected  boolean result;
+
+    public boolean getResult() {
+        return this.result;
+    }
+
+    public void setResult(boolean result) {
+        this.result = result;
+    }
+
+    public CommonResponseRef(String responseBody, int status) {
+        super(responseBody, status);
+    }
+
+    public CommonResponseRef(){
+        super("",0);
+    }
+
+    public void setOrcId(Long orcId) {
+        this.orcId = orcId;
+    }
+
+    public Long getOrcId() {
+        return orcId;
+    }
+
+    public String getContent() {
+        return this.content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/CopyRequestRef.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/CopyRequestRef.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.ref;
+
+
+public interface CopyRequestRef extends WorkspaceRequestRef {
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/CreateRequestRef.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/CreateRequestRef.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.ref;
+
+
+public interface CreateRequestRef  extends WorkspaceRequestRef {
+
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/DSSCommonResponseRef.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/DSSCommonResponseRef.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.ref;
+
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+
+import java.text.SimpleDateFormat;
+import java.util.Map;
+
+
+public class DSSCommonResponseRef extends CommonResponseRef {
+
+    private ObjectMapper jacksonJson = new ObjectMapper();
+
+    public DSSCommonResponseRef(String responseBody) throws Exception {
+        super(responseBody, 0);
+        if (responseMap.containsKey("status")) {
+            status = getInt(responseMap.get("status"));
+            if (status != 0 && status != 200) {
+                errorMsg = responseMap.get("message").toString();
+            }
+        } else if (responseMap.containsKey("header")) {
+            Map<String, Object> headerMap = (Map<String, Object>) responseMap.get("header");
+            if (headerMap.containsKey("code")) {
+                status = getInt(headerMap.get("code"));
+                if (status != 0 && status != 200) {
+                    errorMsg = headerMap.get("msg").toString();
+                }
+            }
+        }
+    }
+
+    public static Integer getInt(Object original){
+        if(original instanceof Double){
+            return ((Double) original).intValue();
+        }
+        return (Integer) original;
+    }
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/DeleteRequestRef.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/DeleteRequestRef.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.ref;
+
+
+public interface DeleteRequestRef extends WorkspaceRequestRef {
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/ExecutionRequestRef.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/ExecutionRequestRef.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.ref;
+
+import java.util.Map;
+
+public interface ExecutionRequestRef extends WorkspaceRequestRef {
+
+    /**
+     * 获取的node所属的project的id
+     * @return
+     */
+    long getProjectId();
+
+    /**
+     * 获取node所属的project的name
+     * @return
+     */
+    String getProjectName();
+    String getOrchestratorName();
+
+    String getOrchestratorVersion();
+
+    long getOrchestratorId();
+
+    /**
+     * 获取到Node的执行内容,执行内容是以Map的形式的
+     * @return
+     */
+    Map<String, Object> getJobContent();
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/ExportRequestRef.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/ExportRequestRef.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.ref;
+
+
+public interface ExportRequestRef extends WorkspaceRequestRef {
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/ImportRequestRef.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/ImportRequestRef.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.ref;
+
+
+public interface ImportRequestRef extends WorkspaceRequestRef {
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/NodeRequestRef.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/NodeRequestRef.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.ref;
+
+import java.util.Map;
+
+
+public interface NodeRequestRef extends CommonRequestRef, CreateRequestRef,UpdateRequestRef {
+
+     void setNodeType(String nodeType);
+
+     String getNodeType();
+
+     void setJobContent(Map<String, Object> jobContent);
+
+     Map<String, Object> getJobContent();
+
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/OpenRequestRef.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/OpenRequestRef.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.ref;
+
+
+public interface OpenRequestRef extends WorkspaceRequestRef {
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/UpdateCSRequestRef.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/UpdateCSRequestRef.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.ref;
+
+public interface UpdateCSRequestRef extends NodeRequestRef {
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/UpdateRequestRef.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/UpdateRequestRef.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.ref;
+
+
+public interface UpdateRequestRef extends WorkspaceRequestRef {
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/UrlResponseRef.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/UrlResponseRef.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.ref;
+
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+
+
+public interface UrlResponseRef extends ResponseRef {
+
+    String getUrl();
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/WorkspaceRequestRef.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/WorkspaceRequestRef.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.ref;
+
+import com.webank.wedatasphere.dss.standard.app.sso.Workspace;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.RequestRef;
+
+public interface WorkspaceRequestRef extends RequestRef {
+
+    default void setWorkspace(Workspace workspace){
+
+    }
+
+    default Workspace getWorkspace(){
+        return null;
+    }
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/impl/CommonRequestRefImpl.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/impl/CommonRequestRefImpl.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.ref.impl;
+
+import com.google.common.collect.Maps;
+import com.webank.wedatasphere.dss.common.label.DSSLabel;
+import com.webank.wedatasphere.dss.standard.app.development.ref.CommonRequestRef;
+import com.webank.wedatasphere.dss.standard.app.sso.Workspace;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.AbstractRequestRef;
+
+import java.util.List;
+import java.util.Map;
+
+
+public  class CommonRequestRefImpl extends AbstractRequestRef implements CommonRequestRef {
+
+    protected String userName;
+    protected String name;
+    protected Long projectId;
+    protected String projectName;
+    protected String orcName;
+    protected Long orcId;
+    protected Workspace workspace;
+    protected String type;
+    protected String workspaceName;
+    protected List<DSSLabel> dssLabelList;
+    protected String contextID;
+
+    @Override
+    public String getUserName() {
+        return userName;
+    }
+
+    @Override
+    public void setUserName(String username) {
+        this.userName = username;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public void setProjectId(Long projectId) {
+        this.projectId = projectId;
+    }
+
+    @Override
+    public Long getProjectId() {
+        return projectId;
+    }
+
+    @Override
+    public String getProjectName() {
+        return projectName;
+    }
+
+    @Override
+    public void setProjectName(String projectName) {
+        this.projectName = projectName;
+    }
+
+    @Override
+    public String getOrcName() {
+        return orcName;
+    }
+
+    @Override
+    public void setOrcName(String orcName) {
+        this.orcName = orcName;
+    }
+
+    @Override
+    public Long getOrcId() {
+        return orcId;
+    }
+
+    @Override
+    public void setOrcId(Long orcId) {
+        this.orcId = orcId;
+    }
+
+    @Override
+    public Workspace getWorkspace() {
+        return workspace;
+    }
+
+    @Override
+    public void setWorkspace(Workspace workspace) {
+        this.workspace = workspace;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public void setWorkspaceName(String workspaceName) {
+     this.workspaceName = workspaceName;
+    }
+
+    @Override
+    public String getWorkspaceName() {
+        return this.workspaceName;
+    }
+
+
+    @Override
+    public void setDSSLabels(List<DSSLabel> dssLabels) {
+        this.dssLabelList = dssLabels;
+    }
+
+    @Override
+    public List<DSSLabel> getDSSLabels() {
+        return dssLabelList;
+    }
+
+    @Override
+    public String getContextID() {
+        return contextID;
+    }
+
+    @Override
+    public void setContextID(String contextID) {
+        this.contextID = contextID;
+    }
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/impl/NodeRequestRefImpl.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/ref/impl/NodeRequestRefImpl.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.ref.impl;
+
+import com.webank.wedatasphere.dss.standard.app.development.ref.NodeRequestRef;
+
+import java.util.Map;
+
+
+public class NodeRequestRefImpl extends CommonRequestRefImpl implements NodeRequestRef{
+
+    protected String nodeType;
+
+    protected Map<String, Object> jobContent;
+
+    @Override
+    public String getNodeType() {
+        return nodeType;
+    }
+
+    @Override
+    public void setNodeType(String nodeType) {
+        this.nodeType = nodeType;
+    }
+
+    @Override
+    public Map<String, Object> getJobContent() {
+        return jobContent;
+    }
+
+    @Override
+    public void setJobContent(Map<String, Object> jobContent) {
+        this.jobContent = jobContent;
+    }
+
+    @Override
+    public String getName() {
+        if(name == null){
+            name = jobContent.get("title").toString();
+        }
+        return name;
+    }
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/AbstractDevelopmentService.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/AbstractDevelopmentService.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.service;
+
+import com.webank.wedatasphere.dss.common.label.DSSLabel;
+import com.webank.wedatasphere.dss.standard.app.development.operation.DevelopmentOperation;
+import com.webank.wedatasphere.dss.standard.app.development.standard.DevelopmentIntegrationStandard;
+import com.webank.wedatasphere.dss.standard.app.sso.request.SSORequestService;
+import com.webank.wedatasphere.dss.standard.common.app.AppSingletonIntegrationServiceImpl;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class AbstractDevelopmentService extends AppSingletonIntegrationServiceImpl<DevelopmentOperation, SSORequestService> implements DevelopmentService {
+
+    private List<DSSLabel> dssLabels = new ArrayList<>();
+    private DevelopmentIntegrationStandard appStandard;
+
+    public void setLabels(List<DSSLabel> labels) {
+        dssLabels = labels;
+    }
+
+    @Override
+    public void setAppStandard(DevelopmentIntegrationStandard appStandard) {
+        this.appStandard = appStandard;
+    }
+
+    @Override
+    public DevelopmentIntegrationStandard getAppStandard() {
+        return appStandard;
+    }
+
+    @Override
+    public List<DSSLabel> getLabels() {
+        return dssLabels;
+    }
+
+    @Override
+    protected void initOperation(DevelopmentOperation operation) {
+        operation.setDevelopmentService(this);
+    }
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/AbstractRefCRUDService.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/AbstractRefCRUDService.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.service;
+
+import com.webank.wedatasphere.dss.standard.app.development.operation.RefCopyOperation;
+import com.webank.wedatasphere.dss.standard.app.development.operation.RefCreationOperation;
+import com.webank.wedatasphere.dss.standard.app.development.operation.RefDeletionOperation;
+import com.webank.wedatasphere.dss.standard.app.development.operation.RefUpdateOperation;
+import com.webank.wedatasphere.dss.standard.app.development.ref.CopyRequestRef;
+import com.webank.wedatasphere.dss.standard.app.development.ref.CreateRequestRef;
+import com.webank.wedatasphere.dss.standard.app.development.ref.DeleteRequestRef;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.RequestRef;
+
+public abstract class AbstractRefCRUDService extends AbstractDevelopmentService implements RefCRUDService {
+
+    protected abstract <K extends CreateRequestRef> RefCreationOperation<K> createRefCreationOperation();
+
+    protected abstract <K extends CopyRequestRef> RefCopyOperation<K> createRefCopyOperation();
+
+    protected abstract <K extends RequestRef> RefUpdateOperation<K> createRefUpdateOperation();
+
+    protected abstract <K extends DeleteRequestRef> RefDeletionOperation<K> createRefDeletionOperation();
+
+    @Override
+    public <K extends CreateRequestRef> RefCreationOperation<K> getRefCreationOperation() {
+        return getOrCreate(this::createRefCreationOperation, RefCreationOperation.class);
+    }
+
+    @Override
+    public <K extends CopyRequestRef> RefCopyOperation<K> getRefCopyOperation() {
+         return getOrCreate(this::createRefCopyOperation, RefCopyOperation.class);
+    }
+
+    @Override
+    public <K extends RequestRef> RefUpdateOperation<K> getRefUpdateOperation() {
+        return getOrCreate(this::createRefUpdateOperation, RefUpdateOperation.class);
+    }
+
+    @Override
+    public <K extends DeleteRequestRef> RefDeletionOperation<K> getRefDeletionOperation() {
+        return getOrCreate(this::createRefDeletionOperation, RefDeletionOperation.class);
+    }
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/AbstractRefExecutionService.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/AbstractRefExecutionService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.service;
+
+import com.webank.wedatasphere.dss.standard.app.development.operation.RefExecutionOperation;
+
+public abstract class AbstractRefExecutionService extends AbstractDevelopmentService implements RefExecutionService {
+
+   public abstract RefExecutionOperation createRefExecutionOperation();
+
+   @Override
+   public RefExecutionOperation getRefExecutionOperation() {
+          return getOrCreate(this::createRefExecutionOperation, RefExecutionOperation.class);
+   }
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/AbstractRefExportService.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/AbstractRefExportService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.service;
+
+import com.webank.wedatasphere.dss.standard.app.development.operation.RefExportOperation;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.RequestRef;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+
+public abstract class AbstractRefExportService extends AbstractDevelopmentService implements RefExportService {
+
+  protected abstract <K extends RequestRef> RefExportOperation<K> createRefExportOperation();
+
+  @Override
+  public <K extends RequestRef> RefExportOperation<K> getRefExportOperation() {
+    return getOrCreate(this::createRefExportOperation, RefExportOperation.class);
+  }
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/AbstractRefImportService.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/AbstractRefImportService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.service;
+
+import com.webank.wedatasphere.dss.standard.app.development.operation.RefImportOperation;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.RequestRef;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+
+
+public abstract class AbstractRefImportService extends AbstractDevelopmentService implements RefImportService {
+
+    protected abstract <K extends RequestRef> RefImportOperation<K> createRefImportOperation();
+
+    @Override
+    public <K extends RequestRef> RefImportOperation<K> getRefImportOperation() {
+        return getOrCreate(this::createRefImportOperation, RefImportOperation.class);
+    }
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/AbstractRefQueryService.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/AbstractRefQueryService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.service;
+
+import com.webank.wedatasphere.dss.standard.app.development.operation.RefQueryOperation;
+
+
+public abstract class AbstractRefQueryService extends AbstractDevelopmentService implements RefQueryService {
+
+    protected abstract RefQueryOperation createRefQueryOperation();
+
+    @Override
+    public RefQueryOperation getRefQueryOperation() {
+        return getOrCreate(this::createRefQueryOperation, RefQueryOperation.class);
+    }
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/DevelopmentService.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/DevelopmentService.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.service;
+
+
+import com.webank.wedatasphere.dss.common.label.DSSLabel;
+import com.webank.wedatasphere.dss.standard.app.development.standard.DevelopmentIntegrationStandard;
+import com.webank.wedatasphere.dss.standard.app.sso.request.SSORequestService;
+import com.webank.wedatasphere.dss.standard.common.app.AppIntegrationService;
+import java.util.List;
+
+public interface DevelopmentService extends AppIntegrationService<SSORequestService> {
+
+    void setAppStandard(DevelopmentIntegrationStandard appStandard);
+
+    DevelopmentIntegrationStandard getAppStandard();
+
+    /**
+     * Labels by default.
+     * @return All default labels
+     */
+    List<DSSLabel> getLabels();
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/RefCRUDService.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/RefCRUDService.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.service;
+
+
+import com.webank.wedatasphere.dss.standard.app.development.operation.RefCopyOperation;
+import com.webank.wedatasphere.dss.standard.app.development.operation.RefCreationOperation;
+import com.webank.wedatasphere.dss.standard.app.development.operation.RefDeletionOperation;
+import com.webank.wedatasphere.dss.standard.app.development.operation.RefUpdateOperation;
+import com.webank.wedatasphere.dss.standard.app.development.ref.CopyRequestRef;
+import com.webank.wedatasphere.dss.standard.app.development.ref.CreateRequestRef;
+import com.webank.wedatasphere.dss.standard.app.development.ref.DeleteRequestRef;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.RequestRef;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+
+public interface RefCRUDService extends DevelopmentService {
+
+     <K extends CreateRequestRef> RefCreationOperation<K> getRefCreationOperation();
+
+     <K extends CopyRequestRef> RefCopyOperation<K> getRefCopyOperation();
+
+     <K extends RequestRef> RefUpdateOperation<K> getRefUpdateOperation();
+
+     <K extends DeleteRequestRef> RefDeletionOperation<K> getRefDeletionOperation();
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/RefExecutionService.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/RefExecutionService.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.service;
+
+import com.webank.wedatasphere.dss.standard.app.development.operation.RefExecutionOperation;
+
+
+public interface RefExecutionService extends DevelopmentService {
+     RefExecutionOperation getRefExecutionOperation();
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/RefExportService.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/RefExportService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.service;
+
+import com.webank.wedatasphere.dss.standard.app.development.operation.RefExportOperation;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.RequestRef;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+
+
+public interface RefExportService extends DevelopmentService {
+    <K extends RequestRef> RefExportOperation<K> getRefExportOperation();
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/RefImportService.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/RefImportService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.service;
+
+import com.webank.wedatasphere.dss.standard.app.development.operation.RefImportOperation;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.RequestRef;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+
+public interface RefImportService extends DevelopmentService {
+
+    <K extends RequestRef> RefImportOperation<K> getRefImportOperation();
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/RefQueryService.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/service/RefQueryService.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.service;
+
+import com.webank.wedatasphere.dss.standard.app.development.operation.RefQueryOperation;
+
+public interface RefQueryService extends DevelopmentService {
+
+    RefQueryOperation getRefQueryOperation();
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/standard/AbstractDevelopmentIntegrationStandard.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/standard/AbstractDevelopmentIntegrationStandard.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.standard;
+
+import com.webank.wedatasphere.dss.standard.app.development.service.*;
+import com.webank.wedatasphere.dss.standard.app.sso.request.SSORequestService;
+import com.webank.wedatasphere.dss.standard.common.core.AbstractAppIntegrationStandard;
+import com.webank.wedatasphere.dss.standard.common.desc.AppInstance;
+import com.webank.wedatasphere.dss.standard.common.exception.AppStandardErrorException;
+
+import java.io.IOException;
+
+public abstract class AbstractDevelopmentIntegrationStandard
+    extends AbstractAppIntegrationStandard<DevelopmentService, SSORequestService> implements DevelopmentIntegrationStandard {
+
+    @Override
+    protected <T extends DevelopmentService> void initService(T service) {
+        service.setAppStandard(this);
+    }
+
+    @Override
+    public RefCRUDService getRefCRUDService(AppInstance appInstance) {
+        return getOrCreate(appInstance, this::createRefCRUDService, RefCRUDService.class);
+    }
+
+    protected abstract RefCRUDService createRefCRUDService();
+
+    @Override
+    public RefExecutionService getRefExecutionService(AppInstance appInstance) {
+        return getOrCreate(appInstance, this::createRefExecutionService, RefExecutionService.class);
+    }
+
+    protected abstract RefExecutionService createRefExecutionService();
+
+    @Override
+    public RefExportService getRefExportService(AppInstance appInstance) {
+        return getOrCreate(appInstance, this::createRefExportService, RefExportService.class);
+    }
+
+    protected abstract RefExportService createRefExportService();
+
+    @Override
+    public RefImportService getRefImportService(AppInstance appInstance) {
+        return getOrCreate(appInstance, this::createRefImportService, RefImportService.class);
+    }
+
+    protected abstract RefImportService createRefImportService();
+
+    @Override
+    public RefQueryService getRefQueryService(AppInstance appInstance) {
+        return getOrCreate(appInstance, this::createRefQueryService, RefQueryService.class);
+    }
+
+    protected abstract RefQueryService createRefQueryService();
+
+
+    @Override
+    public void init() throws AppStandardErrorException {
+
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/standard/DevelopmentIntegrationStandard.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/standard/DevelopmentIntegrationStandard.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.standard;
+
+
+import com.webank.wedatasphere.dss.standard.app.development.service.*;
+import com.webank.wedatasphere.dss.standard.app.sso.request.SSORequestService;
+import com.webank.wedatasphere.dss.standard.common.core.AppIntegrationStandard;
+import com.webank.wedatasphere.dss.standard.common.desc.AppInstance;
+
+public interface DevelopmentIntegrationStandard extends AppIntegrationStandard<SSORequestService> {
+
+    RefCRUDService getRefCRUDService(AppInstance appInstance);
+
+    RefExecutionService getRefExecutionService(AppInstance appInstance);
+
+    RefExportService getRefExportService(AppInstance appInstance);
+
+    RefImportService getRefImportService(AppInstance appInstance);
+
+    RefQueryService getRefQueryService(AppInstance appInstance);
+
+
+    @Override
+    default String getStandardName() {
+        return "developmentIntegrationStandard";
+    }
+
+    @Override
+    default int getGrade() {
+        return 3;
+    }
+
+    @Override
+    default boolean isNecessary() {
+        return false;
+    }
+
+}

--- a/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/standard/OnlyExecutionDevelopmentStandard.java
+++ b/dss-standard/development-standard/development-process-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/development/standard/OnlyExecutionDevelopmentStandard.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.development.standard;
+
+import com.webank.wedatasphere.dss.standard.app.development.service.*;
+
+
+public abstract class OnlyExecutionDevelopmentStandard extends AbstractDevelopmentIntegrationStandard {
+
+    @Override
+    protected RefCRUDService createRefCRUDService() {
+        return null;
+}
+
+    @Override
+    protected RefExportService createRefExportService() {
+        return null;
+    }
+
+    @Override
+    protected RefImportService createRefImportService() {
+        return null;
+    }
+
+    @Override
+    protected RefQueryService createRefQueryService() {
+        return null;
+    }
+
+}

--- a/dss-standard/dss-standard-common/pom.xml
+++ b/dss-standard/dss-standard-common/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>dss</artifactId>
+    <groupId>com.webank.wedatasphere.dss</groupId>
+    <version>1.0.0</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>dss-standard-common</artifactId>
+
+
+  <dependencies>
+
+    <dependency>
+      <groupId>com.webank.wedatasphere.linkis</groupId>
+      <artifactId>linkis-common</artifactId>
+      <version>${linkis.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.webank.wedatasphere.dss</groupId>
+      <artifactId>dss-common</artifactId>
+      <version>${dss.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>${reflections.version}</version>
+    </dependency>
+
+  </dependencies>
+
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/*.yml</exclude>
+            <exclude>**/*.properties</exclude>
+            <exclude>**/*.sh</exclude>
+            <exclude>**/log4j2.xml</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <source>8</source>
+                <target>8</target>
+            </configuration>
+        </plugin>
+    </plugins>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
+    <finalName>${project.artifactId}-${project.version}</finalName>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>product</id>
+      <properties>
+        <project.release.version>1.0.0-SNAPSHOT</project.release.version>
+      </properties>
+    </profile>
+  </profiles>
+
+</project>

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/app/AppIntegrationService.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/app/AppIntegrationService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.app;
+
+import com.webank.wedatasphere.dss.standard.common.desc.AppInstance;
+import com.webank.wedatasphere.dss.standard.common.service.AppService;
+
+
+public interface AppIntegrationService<T extends AppService> extends AppService {
+
+    void setSSORequestService(T ssoRequestService);
+
+    T getSSORequestService();
+
+    AppInstance getAppInstance();
+
+    void setAppInstance(AppInstance appInstance);
+
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/app/AppIntegrationServiceImpl.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/app/AppIntegrationServiceImpl.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.app;
+
+
+import com.webank.wedatasphere.dss.standard.common.desc.AppInstance;
+import com.webank.wedatasphere.dss.standard.common.service.AppService;
+import com.webank.wedatasphere.dss.standard.common.service.AppServiceImpl;
+
+
+public class AppIntegrationServiceImpl<T extends AppService> extends AppServiceImpl implements AppIntegrationService<T> {
+
+    private T ssoRequestService;
+    private AppInstance appInstance;
+
+    @Override
+    public void setSSORequestService(T ssoRequestService) {
+        this.ssoRequestService = ssoRequestService;
+    }
+
+    @Override
+    public T getSSORequestService() {
+        return ssoRequestService;
+    }
+
+    @Override
+    public AppInstance getAppInstance() {
+        return appInstance;
+    }
+
+    @Override
+    public void setAppInstance(AppInstance appInstance) {
+        this.appInstance = appInstance;
+    }
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/app/AppSingletonIntegrationServiceImpl.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/app/AppSingletonIntegrationServiceImpl.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.app;
+
+import com.webank.wedatasphere.dss.standard.common.service.AppService;
+import com.webank.wedatasphere.dss.standard.common.service.Operation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+
+public class AppSingletonIntegrationServiceImpl<O extends Operation, T extends AppService> extends AppIntegrationServiceImpl<T> {
+
+    private final List<O> appOperations = new ArrayList<>();
+
+    protected <TO extends O> TO getOrCreate(Supplier<TO> create, Class<TO> clazz) {
+        Supplier<TO> createAndPut = () -> {
+            TO t = create.get();
+            if(t == null) {
+                return null;
+            }
+            initOperation(t);
+            appOperations.add(t);
+            return t;
+        };
+        Supplier<Optional<TO>> filterOperation = () -> appOperations.stream().filter(clazz::isInstance).findFirst().map(operation -> (TO) operation);
+        return filterOperation.get().orElseGet(() -> {
+            synchronized (appOperations) {
+                return filterOperation.get().orElseGet(createAndPut);
+            }
+        });
+    }
+
+    protected void initOperation(O operation) {}
+
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/core/AbstractAppIntegrationStandard.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/core/AbstractAppIntegrationStandard.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.core;
+
+import com.webank.wedatasphere.dss.standard.common.app.AppIntegrationService;
+import com.webank.wedatasphere.dss.standard.common.desc.AppInstance;
+import com.webank.wedatasphere.dss.standard.common.service.AppService;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+
+public abstract class AbstractAppIntegrationStandard<Service extends AppIntegrationService, SSORequestService extends AppService>
+    implements AppIntegrationStandard<SSORequestService> {
+
+    private final Map<AppInstance, List<Service>> appServices = new HashMap<>();
+    private SSORequestService ssoRequestService;
+
+    protected <T extends Service> T getOrCreate(AppInstance appInstance, Supplier<T> create, Class<T> clazz) {
+        Supplier<T> createAndPut = () -> {
+            T t = create.get();
+            if(t == null) {
+                return null;
+            }
+            t.setSSORequestService(ssoRequestService);
+            t.setAppInstance(appInstance);
+            initService(t);
+            appServices.get(appInstance).add(t);
+            return t;
+        };
+        if(!appServices.containsKey(appInstance)) {
+            synchronized (appServices) {
+                if(!appServices.containsKey(appInstance)) {
+                    appServices.put(appInstance, new ArrayList<>());
+                    return createAndPut.get();
+                }
+            }
+        }
+        final List<Service> services = appServices.get(appInstance);
+        Supplier<Optional<T>> filterService = () -> services.stream().filter(clazz::isInstance).findFirst().map(service -> (T) service);
+        return filterService.get().orElseGet(() -> {
+            synchronized (services) {
+                return filterService.get().orElseGet(createAndPut);
+            }
+        });
+    }
+
+    protected <T extends Service> void initService(T service) {}
+
+    @Override
+    public void setSSORequestService(SSORequestService ssoRequestService) {
+        this.ssoRequestService = ssoRequestService;
+    }
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/core/AppIntegrationStandard.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/core/AppIntegrationStandard.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.core;
+
+
+import com.webank.wedatasphere.dss.standard.common.service.AppService;
+
+
+public interface AppIntegrationStandard<SSORequestService extends AppService> extends AppStandard {
+
+    void setSSORequestService(SSORequestService ssoService);
+
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/core/AppStandard.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/core/AppStandard.java
@@ -21,9 +21,7 @@ import com.webank.wedatasphere.dss.standard.common.exception.AppStandardErrorExc
 
 import java.io.Closeable;
 
-/**
- * Created by enjoyyin on 2020/9/1.
- */
+
 public interface AppStandard extends Closeable {
 
     String getStandardName();

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/core/AppStandard.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/core/AppStandard.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.core;
+
+
+import com.webank.wedatasphere.dss.standard.common.exception.AppStandardErrorException;
+
+import java.io.Closeable;
+
+/**
+ * Created by enjoyyin on 2020/9/1.
+ */
+public interface AppStandard extends Closeable {
+
+    String getStandardName();
+
+    int getGrade();
+
+    void init() throws AppStandardErrorException;
+
+    /**
+     *  是否必须
+     * @return true 表示必须，false表示非必须标准
+     */
+    default boolean isNecessary() {
+        return false;
+    }
+
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/desc/AppDesc.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/desc/AppDesc.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.desc;
+import com.webank.wedatasphere.dss.common.label.DSSLabel;
+import com.webank.wedatasphere.dss.standard.common.exception.NoSuchAppInstanceException;
+
+import java.util.List;
+
+
+public interface AppDesc {
+
+    String getAppName();
+
+    List<AppInstance> getAppInstances();
+
+    /**
+     * 对于每个AppConn而言，会拥有多个AppInstance，如需要获取相应的AppInstance，
+     * 通过传入的labels来进行匹配。
+     * 返回的List实例，其中第0个是匹配程度最大的实例。
+     * */
+    List<AppInstance> getAppInstancesByLabels(List<DSSLabel> labels) throws NoSuchAppInstanceException;
+
+    void addAppInstance(AppInstance appInstance);
+
+    void removeAppInstance(AppInstance appInstance);
+
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/desc/AppDescImpl.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/desc/AppDescImpl.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.desc;
+
+
+import com.webank.wedatasphere.dss.common.label.DSSLabel;
+import com.webank.wedatasphere.dss.standard.common.exception.NoSuchAppInstanceException;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+
+public class AppDescImpl implements AppDesc {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AppDescImpl.class);
+
+    private String appName;
+    private List<AppInstance> appInstances = new ArrayList<>();
+
+    @Override
+    public String getAppName() {
+        return appName;
+    }
+
+    public void setAppName(String appName) {
+        this.appName = appName;
+    }
+
+    @Override
+    public List<AppInstance> getAppInstances() {
+        return appInstances;
+    }
+
+    @Override
+    public List<AppInstance> getAppInstancesByLabels(List<DSSLabel> labels) throws NoSuchAppInstanceException{
+        // todo~！
+        // 1. 通过用户自定义的比较器完成的排序，返回最前一个appInstance
+        // 2. 返回与labels完全匹配的appInstance
+        AppInstance targetAppInstance = null;
+        int similarity = 0;
+        int maxSimilarity = 0;
+        for(AppInstance appInstance: appInstances) {
+            similarity = 0;
+            List<DSSLabel> targetLabels = appInstance.getLabels();
+            for(DSSLabel label: targetLabels) {
+                for(DSSLabel userLabel: labels) {
+                    // if user's label equal the target label, then the similarity increase.
+                    if (isEqualLabel(userLabel,label)) {
+                        similarity++;
+                    }
+                    // if current similarity bigger than the maxSimilarity.
+                    if (similarity > maxSimilarity) {
+                        maxSimilarity = similarity;
+                        targetAppInstance = appInstance;
+                    }
+                }
+            }
+        }
+        // if all the labels is different form the target, then return null.
+        if(maxSimilarity <= 0) {
+            LOG.error("{} has no such AppInstance machs the labels: {}", appName, labels);
+            throw new NoSuchAppInstanceException(60002, "No such AppInstance machs the labels.");
+        }
+        return Arrays.asList(targetAppInstance);
+    }
+
+    //判断两个label是否相等
+    public boolean isEqualLabel(DSSLabel userLabel,DSSLabel label){
+        boolean flag = false;
+
+        DSSLabel tempUserLabel = (DSSLabel) userLabel;
+        String userEnv = tempUserLabel.getValue().get(tempUserLabel.getLabelKey());
+
+        DSSLabel tempLabel = (DSSLabel) label;
+        String instanceEnv = tempLabel.getValue().get(tempLabel.getLabelKey());
+
+        if (StringUtils.isNotBlank(userEnv) && userEnv.equalsIgnoreCase(instanceEnv)) {
+            flag = true;
+        }
+        return flag;
+    }
+
+    public List<AppInstance> getAppInstancesByLabels(List<DSSLabel> labels, Comparator comparator) {
+        return null;
+    }
+
+    @Override
+    public void addAppInstance(AppInstance appInstance) {
+        appInstances.add(appInstance);
+    }
+
+    @Override
+    public void removeAppInstance(AppInstance appInstance) {
+        appInstances.remove(appInstance);
+    }
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/desc/AppInstance.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/desc/AppInstance.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.desc;
+import com.webank.wedatasphere.dss.common.label.DSSLabel;
+
+import java.util.List;
+import java.util.Map;
+
+
+public interface AppInstance {
+
+    Long getId();
+
+    String getBaseUrl();
+
+    Map<String, Object> getConfig();
+
+    List<DSSLabel> getLabels();
+
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/desc/AppInstanceImpl.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/desc/AppInstanceImpl.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.desc;
+
+import com.google.common.base.Objects;
+import com.webank.wedatasphere.dss.common.label.DSSLabel;
+
+import java.util.List;
+import java.util.Map;
+
+
+public class AppInstanceImpl implements AppInstance {
+
+    private Long id;
+    private String baseUrl;
+    private Map<String, Object> config;
+    private List<DSSLabel> labels;
+
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    @Override
+    public Map<String, Object> getConfig() {
+        return config;
+    }
+
+    public void setConfig(Map<String, Object> config) {
+        this.config = config;
+    }
+
+    @Override
+    public List<DSSLabel> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(List<DSSLabel> labels) {
+        this.labels = labels;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AppInstanceImpl that = (AppInstanceImpl) o;
+        return Objects.equal(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/AbstractRequestRef.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/AbstractRequestRef.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.entity.ref;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+public abstract class AbstractRequestRef implements RequestRef {
+
+    private Map<String, Object> parameters = new HashMap<>();
+    private String name;
+    private String type;
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public Object getParameter(String key) {
+        return parameters.get(key);
+    }
+
+    @Override
+    public void setParameter(String key, Object value) {
+        parameters.put(key, value);
+    }
+
+    @Override
+    public Map<String, Object> getParameters() {
+        return parameters;
+    }
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/AbstractResponseRef.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/AbstractResponseRef.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.entity.ref;
+
+import java.util.Map;
+
+
+public abstract class AbstractResponseRef implements ResponseRef {
+
+    protected String responseBody;
+    protected int status = -1;
+    protected String errorMsg;
+    protected Map<String, Object> responseMap;
+
+    protected AbstractResponseRef(String responseBody, int status) {
+        this.responseBody = responseBody;
+        this.status = status;
+    }
+
+    @Override
+    public Object getValue(String key) {
+        return toMap().get(key);
+    }
+
+    @Override
+    public String getResponseBody() {
+        return responseBody;
+    }
+
+    @Override
+    public int getStatus() {
+        return status;
+    }
+
+    @Override
+    public boolean isSucceed() {
+        return status == 0 || status == 200;
+    }
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/AppConnRefFactoryUtils.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/AppConnRefFactoryUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.entity.ref;
+
+import com.webank.wedatasphere.dss.common.exception.DSSErrorException;
+import com.webank.wedatasphere.linkis.common.conf.CommonVars;
+
+
+public class AppConnRefFactoryUtils {
+
+    public static final String APP_CONN_PACKAGE_HEADER = CommonVars.apply("wds.dss.appconn.package.header", "com.webank.wedatasphere.dss.appconn.").getValue();
+
+    public static <R extends Ref> R newAppConnRef(Class<R> clazz, String appConnName) throws DSSErrorException {
+        return RefFactory.INSTANCE.newRef(clazz, Thread.currentThread().getContextClassLoader(), APP_CONN_PACKAGE_HEADER + appConnName);
+    }
+
+    public static <R extends Ref> R newAppConnRef(Class<R> clazz, ClassLoader classLoader, String appConnName) throws DSSErrorException {
+        return RefFactory.INSTANCE.newRef(clazz, classLoader, APP_CONN_PACKAGE_HEADER + appConnName);
+    }
+
+    public static <R extends Ref> R newAppConnRefByPackageName(Class<R> clazz, ClassLoader classLoader, String packageName) throws DSSErrorException {
+        return RefFactory.INSTANCE.newRef(clazz, classLoader, packageName);
+    }
+
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/AsyncResponseRef.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/AsyncResponseRef.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.entity.ref;
+
+import java.util.function.Consumer;
+
+
+public interface AsyncResponseRef extends ResponseRef {
+
+    long getStartTime();
+
+    boolean isCompleted();
+
+    ResponseRef getResponse();
+
+    void waitForCompleted() throws InterruptedException;
+
+    void notifyMe(Consumer<ResponseRef> notifyListener);
+
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/CommonResponseRef.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/CommonResponseRef.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.entity.ref;
+
+import com.webank.wedatasphere.dss.common.utils.DSSCommonUtils;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.lang.StringUtils;
+
+
+public class CommonResponseRef extends AbstractResponseRef {
+
+    public CommonResponseRef(String responseBody, int status) {
+        super(responseBody, status);
+        init();
+    }
+
+    protected void init() {
+        if(StringUtils.isNotBlank(responseBody)) {
+            responseMap = DSSCommonUtils.COMMON_GSON.fromJson(responseBody, Map.class);
+        } else {
+            responseMap = new HashMap<>();
+        }
+    }
+
+    public CommonResponseRef(){
+        this("",0);
+    }
+
+    @Override
+    public Map<String, Object> toMap() {
+        return responseMap;
+    }
+
+    @Override
+    public String getErrorMsg() {
+        return errorMsg;
+    }
+
+    @Override
+    public Object getValue(String key) {
+        return this.responseMap.get(key);
+    }
+
+    public void addResponse(String key, Object value){
+        this.responseMap.put(key, value);
+    }
+
+    public static CommonResponseRef success() {
+        return new CommonResponseRef();
+    }
+
+    public static CommonResponseRef success(String message) {
+        CommonResponseRef commonResponseRef = new CommonResponseRef();
+        commonResponseRef.responseBody = message;
+        return commonResponseRef;
+    }
+
+    public static CommonResponseRef error(String errorMsg, Throwable cause) {
+        CommonResponseRef commonResponseRef = new CommonResponseRef();
+        commonResponseRef.status = 1;
+        commonResponseRef.errorMsg = errorMsg;
+        return commonResponseRef;
+    }
+
+    public static CommonResponseRef error(String errorMsg) {
+        return error(errorMsg, null);
+    }
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/DefaultRefFactory.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/DefaultRefFactory.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.entity.ref;
+
+import com.webank.wedatasphere.dss.common.exception.DSSErrorException;
+import com.webank.wedatasphere.dss.common.utils.DSSExceptionUtils;
+import com.webank.wedatasphere.linkis.common.utils.ClassUtils;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DefaultRefFactory implements RefFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRefFactory.class);
+
+    private class RefKey{
+        private ClassLoader classLoader;
+        private Class<? extends Ref> clazz;
+        private String packageName;
+
+        public RefKey(ClassLoader classLoader, Class<? extends Ref> clazz, String packageName) {
+            this.classLoader = classLoader;
+            this.clazz = clazz;
+            this.packageName = packageName;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            RefKey refKey = (RefKey) o;
+            return com.google.common.base.Objects.equal(classLoader, refKey.classLoader) &&
+                    com.google.common.base.Objects.equal(clazz, refKey.clazz) &&
+                    com.google.common.base.Objects.equal(packageName, refKey.packageName);
+        }
+
+        @Override
+        public int hashCode() {
+            return com.google.common.base.Objects.hashCode(classLoader, clazz, packageName);
+        }
+    }
+
+
+
+    private Map<RefKey, Class<? extends Ref>> cacheMap = new ConcurrentHashMap<>(16);
+
+
+    @Override
+    public <R extends Ref> R newRef(Class<R> clazz) throws DSSErrorException {
+        if(!ClassUtils.isInterfaceOrAbstract(clazz)) {
+            return DSSExceptionUtils.tryAndWarn(Void -> clazz.newInstance());
+        } else {
+            return com.webank.wedatasphere.dss.common.utils.ClassUtils.getInstance(clazz);
+        }
+    }
+
+    @Override
+    public <R extends Ref> R newRef(Class<R> clazz, ClassLoader classLoader, String packageName) throws DSSErrorException {
+        RefKey refKey = new RefKey(classLoader, clazz, packageName);
+        Class<? extends Ref> refClass = cacheMap.get(refKey);
+        if(cacheMap.containsKey(refKey) && refClass != null){
+            return DSSExceptionUtils.tryAndWarn(Void -> (R) refClass.newInstance());
+        } else if(cacheMap.containsKey(refKey) && refClass == null)  {
+            return newRef(clazz);
+        }
+        ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
+        configurationBuilder.addClassLoader(classLoader);
+        configurationBuilder.addClassLoader(clazz.getClassLoader());
+        configurationBuilder.forPackages(packageName);
+        Collection<URL> urls = ClasspathHelper.forClassLoader(classLoader);
+        configurationBuilder.addUrls(urls.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+        configurationBuilder.addScanners(new SubTypesScanner());
+        Reflections reflections = new Reflections(configurationBuilder);
+        Set<? extends Class<? extends R>> subClasses = reflections.getSubTypesOf(clazz).stream()
+                .filter(c -> !ClassUtils.isInterfaceOrAbstract(c)).collect(Collectors.toSet());
+        if(subClasses.isEmpty()){
+            // Put null, so just search it in one time.
+            cacheMap.put(refKey, null);
+            return newRef(clazz);
+        } else {
+            Set<? extends Class<? extends R>> realSubClasses = subClasses;
+            if (subClasses.size() > 1) {
+                LOGGER.warn("subClass of {} size is {}, classes are {}", clazz.getName(), subClasses.size(), subClasses);
+                realSubClasses = subClasses.stream().filter(subClass -> subClass.getName().contains(packageName) && !((Class) subClass).isInterface()).collect(Collectors.toSet());
+                LOGGER.warn("realSubClasses is {} ", realSubClasses);
+            }
+            if (realSubClasses.size() > 1){
+                LOGGER.error("realSubClasses size is bigger than 1");
+                DSSExceptionUtils.dealErrorException(60091, "too many subclass of " + clazz.getName() + "in " + packageName,
+                        DSSErrorException.class);
+            } else if(realSubClasses.size() == 0) {
+                // Put null, so just search it in one time.
+                cacheMap.put(refKey, null);
+                return newRef(clazz);
+            }
+            Class<? extends R> subClass = realSubClasses.iterator().next();
+            cacheMap.put(refKey, subClass);
+            return DSSExceptionUtils.tryAndWarn(Void -> subClass.newInstance());
+        }
+    }
+
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/Ref.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/Ref.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.entity.ref;
+
+public interface Ref {
+
+    @Override
+    boolean equals(Object ref);
+
+    @Override
+    String toString();
+
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/RefFactory.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/RefFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.entity.ref;
+
+import com.webank.wedatasphere.dss.common.exception.DSSErrorException;
+
+
+public interface RefFactory {
+
+    RefFactory INSTANCE = new DefaultRefFactory();
+
+    <R extends Ref> R newRef(Class<R> clazz) throws DSSErrorException;
+
+    /**
+     * 我们要将Ref进行实例化,因为各个Ref都是在的不同的AppConn中进行实例化，所以他们的ClassLoader也是和主ClassLoader是不一样的，
+     * 所以我们需要将实例化AppConn的ClassLoader传入
+     * @param clazz 需要实例化的类继承的接口
+     * @param classLoader 实例化appConn的classloader
+     * @param packageName 包名
+     * @return
+     * @throws Exception
+     */
+    <R extends Ref> R newRef(Class<R> clazz, ClassLoader classLoader, String packageName) throws DSSErrorException;
+
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/RefFactory.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/RefFactory.java
@@ -26,13 +26,14 @@ public interface RefFactory {
     <R extends Ref> R newRef(Class<R> clazz) throws DSSErrorException;
 
     /**
-     * 我们要将Ref进行实例化,因为各个Ref都是在的不同的AppConn中进行实例化，所以他们的ClassLoader也是和主ClassLoader是不一样的，
-     * 所以我们需要将实例化AppConn的ClassLoader传入
-     * @param clazz 需要实例化的类继承的接口
-     * @param classLoader 实例化appConn的classloader
-     * @param packageName 包名
-     * @return
-     * @throws Exception
+     * We need to instantiate Ref, because each Ref is instantiated in a different AppConn,
+     * so their ClassLoader is also different from the main ClassLoader,
+     * so we need to pass in the ClassLoader that instantiates the AppConn.
+     * @param clazz The interface inherited by the class that needs to be instantiated.
+     * @param classLoader Instantiate the classloader of appConn.
+     * @param packageName package name.
+     * @return return a instance of R.
+     * @throws DSSErrorException
      */
     <R extends Ref> R newRef(Class<R> clazz, ClassLoader classLoader, String packageName) throws DSSErrorException;
 

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/RequestRef.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/RequestRef.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.entity.ref;
+import com.webank.wedatasphere.dss.common.label.DSSLabel;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+
+public interface RequestRef extends Ref {
+
+    Object getParameter(String key);
+
+    void setParameter(String key, Object value);
+
+    Map<String, Object> getParameters();
+
+    String getName();
+
+    String getType();
+
+    default List<DSSLabel> getDSSLabels(){
+        return new ArrayList<>();
+    }
+
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/ResponseRef.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/entity/ref/ResponseRef.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.entity.ref;
+
+import java.util.Map;
+
+
+public interface ResponseRef extends Ref {
+
+    Object getValue(String key);
+
+    Map<String, Object> toMap();
+
+    String getResponseBody();
+
+    int getStatus();
+
+    String getErrorMsg();
+
+    boolean isSucceed();
+
+    default boolean isFailed() {
+        return !isSucceed();
+    }
+
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/exception/AppStandardErrorException.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/exception/AppStandardErrorException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.exception;
+
+import com.webank.wedatasphere.dss.common.exception.DSSErrorException;
+
+
+public class AppStandardErrorException extends DSSErrorException {
+
+
+    public AppStandardErrorException(int errorCode, String errorMessage){
+        super(errorCode,errorMessage);
+    }
+
+    public AppStandardErrorException(int errorCode, String message, Throwable cause) {
+        super(errorCode, message);
+        this.initCause(cause);
+    }
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/exception/AppStandardWarnException.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/exception/AppStandardWarnException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.exception;
+
+
+public class AppStandardWarnException extends RuntimeException {
+
+    public AppStandardWarnException(int errorCode, String message) {
+        super(message);
+    }
+
+    public AppStandardWarnException(int errorCode, String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/exception/NoSuchAppInstanceException.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/exception/NoSuchAppInstanceException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.exception;
+
+import com.webank.wedatasphere.dss.common.exception.DSSErrorException;
+
+
+public class NoSuchAppInstanceException extends DSSErrorException {
+
+    public NoSuchAppInstanceException(int errCode, String desc) {
+        super(errCode, desc);
+    }
+
+    public NoSuchAppInstanceException(int errCode, String desc, String ip, int port, String serviceKind) {
+        super(errCode, desc, ip, port, serviceKind);
+    }
+
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/exception/operation/ExternalOperationFailedException.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/exception/operation/ExternalOperationFailedException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.exception.operation;
+
+import com.webank.wedatasphere.dss.standard.common.exception.AppStandardErrorException;
+
+public class ExternalOperationFailedException extends AppStandardErrorException {
+
+    public ExternalOperationFailedException(int errorCode, String message){
+        super(errorCode, message);
+    }
+
+    public ExternalOperationFailedException(int errorCode, String message, Throwable cause) {
+        super(errorCode, message, cause);
+    }
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/service/AppService.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/service/AppService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.service;
+
+
+public interface AppService {
+
+    Operation createOperation(Class<? extends Operation> clazz);
+
+    boolean isOperationExists(Class<? extends Operation> clazz);
+
+    boolean isOperationNecessary(Class<? extends Operation> clazz);
+
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/service/AppServiceImpl.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/service/AppServiceImpl.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.service;
+
+import com.webank.wedatasphere.dss.standard.common.exception.AppStandardWarnException;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+
+public class AppServiceImpl implements AppService {
+
+    private Set<Class<? extends Operation>> necessaryOperations = new HashSet<>();
+
+    protected void registerNecessaryOperation(Class<? extends Operation> clazz) {
+        necessaryOperations.add(clazz);
+    }
+
+    @Override
+    public Operation createOperation(Class<? extends Operation> clazz) {
+        String clazzSimpleName = clazz.getSimpleName();
+        List<Method> methodList = Arrays.stream(this.getClass().getDeclaredMethods())
+            .filter(method -> method.getReturnType() == clazz
+            && method.getParameterCount() == 0).collect(Collectors.toList());
+        if(methodList.size() == 1) {
+            try {
+                return (Operation) methodList.get(0).invoke(this);
+            } catch (ReflectiveOperationException e) {
+                throw new AppStandardWarnException(80020, "Not exists operation: " + clazzSimpleName, e);
+            }
+        } else if(methodList.isEmpty()) {
+            return notFoundOperation(clazz);
+        } else {
+            return multiFoundOperation(clazz);
+        }
+    }
+
+    protected Operation notFoundOperation(Class<? extends Operation> clazz) {
+        throw new AppStandardWarnException(80020, "Not exists operation: " + clazz.getSimpleName());
+    }
+
+    protected Operation multiFoundOperation(Class<? extends Operation> clazz) {
+        throw new AppStandardWarnException(80020, "Multi exists operations: " + clazz.getSimpleName());
+    }
+
+    @Override
+    public boolean isOperationExists(Class<? extends Operation> clazz) {
+        try{
+            return createOperation(clazz) != null;
+        } catch (AppStandardWarnException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isOperationNecessary(Class<? extends Operation> clazz) {
+        boolean isNecessary = necessaryOperations.contains(clazz);
+        if(isNecessary) {
+            return true;
+        } else {
+            return isOperationExists(clazz);
+        }
+    }
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/service/Operation.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/service/Operation.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.service;
+
+
+import com.webank.wedatasphere.dss.standard.common.entity.ref.RequestRef;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+
+/**
+ * Operation是顶层的操作类,对于操作来说，传入一个RequestRef,返回一个ResponseRef
+ */
+public interface Operation<K extends RequestRef, V extends ResponseRef> {
+
+}

--- a/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/utils/AppStandardClassUtils.java
+++ b/dss-standard/dss-standard-common/src/main/java/com/webank/wedatasphere/dss/standard/common/utils/AppStandardClassUtils.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.common.utils;
+
+import com.webank.wedatasphere.dss.common.utils.ClassUtils.ClassHelper;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.reflections.Reflections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is defined for AppConn jar, if some classes in AppConn want to load a class in AppConn jar.
+ */
+public class AppStandardClassUtils extends ClassHelper {
+
+    private static final Map<String, AppStandardClassUtils> INSTANCES = new HashMap<>();
+    private static final Map<String, ClassLoader> CLASS_LOADER_MAP = new HashMap<>();
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AppStandardClassUtils.class);
+
+    public static ClassLoader getClassLoader(String appConnName, Supplier<ClassLoader> createClassLoader) {
+        if(!CLASS_LOADER_MAP.containsKey(appConnName)) {
+            synchronized (AppStandardClassUtils.class) {
+                if(!CLASS_LOADER_MAP.containsKey(appConnName)) {
+                    CLASS_LOADER_MAP.put(appConnName, createClassLoader.get());
+                    LOGGER.info("Has stored {} ClassLoader.", CLASS_LOADER_MAP.size());
+                }
+            }
+        }
+        return CLASS_LOADER_MAP.get(appConnName);
+    }
+
+    public static AppStandardClassUtils getInstance(String appConnName) {
+        if(!INSTANCES.containsKey(appConnName)) {
+            synchronized (AppStandardClassUtils.class) {
+                if(!INSTANCES.containsKey(appConnName)) {
+                    INSTANCES.put(appConnName, new AppStandardClassUtils(appConnName));
+                    LOGGER.info("Has stored {} AppStandardClassUtils.", INSTANCES.size());
+                }
+            }
+        }
+        return INSTANCES.get(appConnName);
+    }
+
+    private Reflections reflection;
+    private String appConnName;
+
+    private AppStandardClassUtils(String appConnName) {
+        this.appConnName = appConnName;
+    }
+
+    @Override
+    protected Reflections getReflections(Class<?> clazz) {
+        if(reflection == null) {
+            synchronized (this) {
+                if(reflection == null) {
+                    ClassLoader classLoader = clazz.getClassLoader();
+                    reflection = new Reflections("com.webank.wedatasphere.dss", CLASS_LOADER_MAP.get(appConnName), classLoader);
+                }
+            }
+        }
+        return reflection;
+    }
+
+}

--- a/dss-standard/pom.xml
+++ b/dss-standard/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>dss</artifactId>
+    <groupId>com.webank.wedatasphere.dss</groupId>
+    <version>1.0.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>dss-standard</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>dss-standard-common</module>
+    <module>sso-standard/sso-integration-standard</module>
+    <module>sso-standard/origin-sso-integration-standard</module>
+    <module>sso-standard/spring-origin-sso-integration-plugin</module>
+    <module>structure-standard/dss-structure-integration-standard</module>
+    <module>structure-standard/dss-project-plugin</module>
+    <module>structure-standard/spring-origin-dss-project-plugin</module>
+    <module>structure-standard/dss-role-plugin</module>
+    <module>development-standard/development-process-standard</module>
+    <module>development-standard/development-process-standard-execution</module>
+  </modules>
+
+</project>

--- a/dss-standard/sso-standard/origin-sso-integration-standard/pom.xml
+++ b/dss-standard/sso-standard/origin-sso-integration-standard/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>dss</artifactId>
+    <groupId>com.webank.wedatasphere.dss</groupId>
+    <version>1.0.0</version>
+    <relativePath>../../../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>dss-origin-sso-integration-standard</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.webank.wedatasphere.linkis</groupId>
+      <artifactId>linkis-gateway-httpclient-support</artifactId>
+      <version>${linkis.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.webank.wedatasphere.dss</groupId>
+      <artifactId>dss-sso-integration-standard</artifactId>
+      <version>${dss.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/dss-standard/sso-standard/origin-sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/origin/OriginSSOIntegrationStandard.scala
+++ b/dss-standard/sso-standard/origin-sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/origin/OriginSSOIntegrationStandard.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.origin
+
+
+import com.webank.wedatasphere.dss.standard.app.sso.{SSOIntegrationStandard, SSOIntegrationStandardFactory}
+import com.webank.wedatasphere.dss.standard.app.sso.origin.client.HttpClient
+import com.webank.wedatasphere.dss.standard.app.sso.origin.plugin.OriginSSOPluginServiceImpl
+import com.webank.wedatasphere.dss.standard.app.sso.origin.request.OriginSSORequestServiceImpl
+import com.webank.wedatasphere.dss.standard.app.sso.plugin.SSOPluginService
+import com.webank.wedatasphere.dss.standard.app.sso.request.SSORequestService
+import com.webank.wedatasphere.dss.standard.common.desc.AppDesc
+
+
+class OriginSSOIntegrationStandard private[origin]() extends SSOIntegrationStandard {
+
+  private val ssoPluginService: SSOPluginService = new OriginSSOPluginServiceImpl
+  private val ssoRequestService: SSORequestService = new OriginSSORequestServiceImpl
+
+  override def getSSORequestService: SSORequestService = ssoRequestService
+
+  override def getSSOPluginService: SSOPluginService = ssoPluginService
+
+  override def init(): Unit = {
+    ssoPluginService.setSSOBuilderService(getSSOBuilderService)
+  }
+
+  override def close(): Unit = HttpClient.close()
+}
+
+// SSO 工厂，通过该工程获取sso集成规范
+class OriginSSOIntegrationStandardFactory extends SSOIntegrationStandardFactory {
+
+  private val ssoIntegrationStandard = new OriginSSOIntegrationStandard
+
+  override def init(): Unit = {
+    ssoIntegrationStandard.init()
+  }
+
+  override def getSSOIntegrationStandard: SSOIntegrationStandard = ssoIntegrationStandard
+}

--- a/dss-standard/sso-standard/origin-sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/origin/client/HttpClient.scala
+++ b/dss-standard/sso-standard/origin-sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/origin/client/HttpClient.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.origin.client
+
+import java.net.URI
+import java.text.SimpleDateFormat
+import java.util
+import java.util.Date
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.webank.wedatasphere.dss.standard.app.sso.builder.DssMsgBuilderOperation.DSSMsg
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.httpclient.Client
+import com.webank.wedatasphere.linkis.httpclient.dws.DWSHttpClient
+import com.webank.wedatasphere.linkis.httpclient.dws.config.DWSClientConfigBuilder
+import com.webank.wedatasphere.linkis.httpclient.request.HttpAction
+import org.apache.commons.io.IOUtils
+import org.apache.http.impl.cookie.BasicClientCookie
+
+import scala.collection.JavaConversions._
+
+
+object HttpClient extends Logging {
+
+  private val dssClients = new util.HashMap[String, DWSHttpClient]
+  private val httpClients = new util.HashMap[String, Client]
+
+
+
+  def getBaseUrl(url: String): String = {
+    val uri = new URI(url)
+    if (uri.getPort > 0){
+      uri.getScheme + "://" + uri.getHost + ":" + uri.getPort
+    } else {
+      uri.getScheme + "://" + uri.getHost
+    }
+  }
+
+  private def getClient[T](url: String, cacheMap: util.HashMap[String, T], createNewClient: String => T): T = {
+    val baseUrl = getBaseUrl(url)
+    if(!cacheMap.containsKey(baseUrl)) baseUrl.intern synchronized {
+      if(!cacheMap.containsKey(baseUrl)) {
+        info("create a new Client for url " + baseUrl)
+        val client = createNewClient(baseUrl)
+        cacheMap.put(baseUrl, client)
+      }
+    }
+    cacheMap.get(baseUrl)
+  }
+
+  def getHttpClient(url: String, appName: String): Client = {
+    val baseUrl = getBaseUrl(url)
+    val clientConfig = DWSClientConfigBuilder.
+      newBuilder().
+      addServerUrl(baseUrl).
+      connectionTimeout(connectTimeout).
+      setDWSVersion("v1").
+      discoveryEnabled(false).
+      maxConnectionSize(maxConnection).
+      readTimeout(readTimeout).build()
+    new DWSHttpClient(clientConfig, appName + "-SSO-Client")
+  }
+
+  def getDSSClient(dssUrl: String): DWSHttpClient = getClient(dssUrl, dssClients, baseUrl => {
+    val clientConfig = DWSClientConfigBuilder.newBuilder().setDWSVersion(dssVersion)
+      .addServerUrl(baseUrl).connectionTimeout(connectTimeout).discoveryEnabled(true)
+      .maxConnectionSize(maxConnection).readTimeout(readTimeout).build()
+    new DWSHttpClient(clientConfig, "DSS-Integration-Standard-Client")
+  })
+
+  def addCookies(dssMsg: DSSMsg, action: HttpAction): Unit =
+    dssMsg.getCookies.foreach { case (key, value) =>
+      val basicClientCookie = new BasicClientCookie(key, value)
+      val domain = Utils.tryCatch(new URI(dssMsg.getDSSUrl).getHost)(_ => HttpClient.getBaseUrl(dssMsg.getDSSUrl))
+      basicClientCookie.setDomain(domain)
+      basicClientCookie.setPath("/")
+      basicClientCookie.setExpiryDate(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 24 * 30L))
+      info("Add cookie for get user info "+basicClientCookie.toString)
+      action.addCookie(basicClientCookie)
+    }
+
+  def close(): Unit = {
+    dssClients.values().foreach(IOUtils.closeQuietly)
+    httpClients.values().foreach(IOUtils.closeQuietly)
+  }
+
+  private var dssVersion = "v1"
+  private var maxConnection = 50
+  private var connectTimeout = 300000
+  private var readTimeout = 300000
+
+  //TODO 切换为linkis-common的JsonUtils
+  val objectMapper = new ObjectMapper().setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ"))
+
+  def setDSSVersion(version: String): Unit = this.dssVersion = version
+  def setMaxConnection(maxConnection: Int): Unit = this.maxConnection = maxConnection
+  def setConnectTimeout(connectTimeout: Int): Unit = this.connectTimeout = connectTimeout
+  def setReadTimeout(readTimeout: Int): Unit = this.readTimeout = readTimeout
+
+}

--- a/dss-standard/sso-standard/origin-sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/origin/plugin/OriginSSOMsgParseOperation.scala
+++ b/dss-standard/sso-standard/origin-sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/origin/plugin/OriginSSOMsgParseOperation.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.origin.plugin
+
+import com.webank.wedatasphere.dss.common.utils.IoUtils
+import com.webank.wedatasphere.dss.standard.app.sso.builder.DssMsgBuilderOperation.DSSMsg
+import com.webank.wedatasphere.dss.standard.app.sso.origin.client.HttpClient
+import com.webank.wedatasphere.dss.standard.app.sso.plugin.AbstractSSOMsgParseOperation
+import com.webank.wedatasphere.linkis.common.utils.Utils
+import com.webank.wedatasphere.linkis.httpclient.Client
+import org.apache.commons.io.IOUtils
+
+
+class OriginSSOMsgParseOperation extends AbstractSSOMsgParseOperation {
+
+  override protected def getUser(dssMsg: DSSMsg): String = {
+    val dssUrl = dssMsg.getDSSUrl
+    val dwsHttpClient:Client=null
+    Utils.tryFinally({
+    val dwsHttpClient = HttpClient.getHttpClient(dssUrl, "DSS")
+    val userInfoAction = new UserInfoAction
+    HttpClient.addCookies(dssMsg, userInfoAction)
+    dwsHttpClient.execute(userInfoAction) match {
+      case userInfoResult: UserInfoResult =>
+        userInfoResult.getUserName
+    }
+  })(IOUtils.closeQuietly(dwsHttpClient))
+  }
+
+}

--- a/dss-standard/sso-standard/origin-sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/origin/plugin/OriginSSOPluginFilter.scala
+++ b/dss-standard/sso-standard/origin-sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/origin/plugin/OriginSSOPluginFilter.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.origin.plugin
+
+import com.webank.wedatasphere.dss.standard.app.sso.SSOIntegrationStandard
+import com.webank.wedatasphere.dss.standard.app.sso.origin.OriginSSOIntegrationStandardFactory
+import com.webank.wedatasphere.dss.standard.app.sso.plugin.filter.SSOPluginFilter
+import com.webank.wedatasphere.linkis.common.utils.Logging
+
+
+abstract class OriginSSOPluginFilter extends SSOPluginFilter with Logging{
+
+  private val factory = new OriginSSOIntegrationStandardFactory
+
+  override def info(str: String): Unit = logger.info(str)
+
+  override protected def getSSOIntegrationStandard: SSOIntegrationStandard = factory.getSSOIntegrationStandard
+}

--- a/dss-standard/sso-standard/origin-sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/origin/plugin/OriginSSOPluginServiceImpl.scala
+++ b/dss-standard/sso-standard/origin-sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/origin/plugin/OriginSSOPluginServiceImpl.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.origin.plugin
+
+import com.webank.wedatasphere.dss.standard.app.sso.builder.SSOBuilderService
+import com.webank.wedatasphere.dss.standard.app.sso.plugin.{SSOMsgParseOperation, SSOPluginService, WorkspacePlugin}
+import com.webank.wedatasphere.dss.standard.common.service.AppServiceImpl
+import com.webank.wedatasphere.linkis.common.utils.Logging
+
+
+class OriginSSOPluginServiceImpl extends AppServiceImpl with SSOPluginService with Logging {
+
+  private var ssoBuilderService: SSOBuilderService = _
+  private val ssoMsgParseOperation = new OriginSSOMsgParseOperation
+  private val workspacePlugin = new OriginWorkspacePlugin
+  workspacePlugin.setDssMsgCacheOperation(createDssMsgCacheOperation())
+
+  override def setSSOBuilderService(ssoBuilderService: SSOBuilderService): Unit = {
+    this.ssoBuilderService = ssoBuilderService
+    ssoMsgParseOperation.setSSOBuilderService(ssoBuilderService)
+
+  }
+
+  override def createSSOMsgParseOperation(): SSOMsgParseOperation = ssoMsgParseOperation
+
+  override def close(): Unit = {}
+
+  override def createWorkspacePluginOperation(): WorkspacePlugin = workspacePlugin
+}

--- a/dss-standard/sso-standard/origin-sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/origin/plugin/OriginWorkspacePlugin.java
+++ b/dss-standard/sso-standard/origin-sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/origin/plugin/OriginWorkspacePlugin.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.origin.plugin;
+
+import com.webank.wedatasphere.dss.standard.app.sso.builder.DssMsgBuilderOperation;
+import com.webank.wedatasphere.dss.standard.app.sso.plugin.AbstractWorkspacePlugin;
+import com.webank.wedatasphere.dss.standard.app.sso.origin.client.HttpClient;
+import com.webank.wedatasphere.linkis.httpclient.dws.DWSHttpClient;
+import java.util.List;
+
+
+public class OriginWorkspacePlugin extends AbstractWorkspacePlugin {
+
+    @Override
+    protected List<String> getAllUsers(DssMsgBuilderOperation.DSSMsg dssMsg) {
+        String dssUrl = dssMsg.getDSSUrl();
+        DWSHttpClient dwsHttpClient = HttpClient.getDSSClient(dssUrl);
+        WorkspaceUsersAction workspaceUsersAction = new WorkspaceUsersAction();
+        HttpClient.addCookies(dssMsg, workspaceUsersAction);
+        WorkspaceUsersResult result = (WorkspaceUsersResult) dwsHttpClient.execute(workspaceUsersAction);
+        return result.getUsers();
+    }
+}

--- a/dss-standard/sso-standard/origin-sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/origin/plugin/UserInfoAction.scala
+++ b/dss-standard/sso-standard/origin-sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/origin/plugin/UserInfoAction.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.origin.plugin
+
+import com.webank.wedatasphere.linkis.httpclient.dws.request.DWSHttpAction
+import com.webank.wedatasphere.linkis.httpclient.request.GetAction
+import com.webank.wedatasphere.linkis.httpclient.request.POSTAction
+
+
+class UserInfoAction extends GetAction with DWSHttpAction {
+  override def suffixURLs: Array[String] = Array("user", "userInfo")
+}
+class WorkspaceUsersAction extends POSTAction with DWSHttpAction {
+  override def getRequestPayload: String = ""
+
+  override def suffixURLs: Array[String] = Array("dss", "getUsersOfWorkspace")
+
+  def setWorkspace(workspace: String): Unit = addRequestPayload("workspaceName", workspace)
+}

--- a/dss-standard/sso-standard/origin-sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/origin/plugin/UserInfoResult.scala
+++ b/dss-standard/sso-standard/origin-sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/origin/plugin/UserInfoResult.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.origin.plugin
+
+import com.webank.wedatasphere.linkis.httpclient.dws.annotation.DWSHttpMessageResult
+import com.webank.wedatasphere.linkis.httpclient.dws.response.DWSResult
+
+import scala.beans.BeanProperty
+
+
+@DWSHttpMessageResult("/api/rest_j/v\\d+/user/userInfo")
+class UserInfoResult extends DWSResult {
+
+  @BeanProperty var userName: String = _
+
+}
+
+@DWSHttpMessageResult("/api/rest_j/v\\d+/dss/getUsersOfWorkspace")
+class WorkspaceUsersResult extends DWSResult {
+
+  @BeanProperty var users: java.util.List[String] = _
+
+}

--- a/dss-standard/sso-standard/origin-sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/origin/request/OriginSSORequestOperation.scala
+++ b/dss-standard/sso-standard/origin-sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/origin/request/OriginSSORequestOperation.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.origin.request
+
+import java.net.{URI, URL, URLDecoder}
+import java.util
+import java.util.Date
+import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
+
+import com.webank.wedatasphere.dss.standard.app.sso.builder.SSOUrlBuilderOperation
+import com.webank.wedatasphere.dss.standard.app.sso.builder.impl.SSOUrlBuilderOperationImpl
+import com.webank.wedatasphere.dss.standard.app.sso.origin.client.HttpClient
+import com.webank.wedatasphere.dss.standard.app.sso.request.SSORequestOperation
+import com.webank.wedatasphere.dss.standard.common.exception.AppStandardErrorException
+import com.webank.wedatasphere.linkis.common.utils.{ByteTimeUtils, Logging, Utils}
+import com.webank.wedatasphere.linkis.httpclient.Client
+import com.webank.wedatasphere.linkis.httpclient.request.HttpAction
+import com.webank.wedatasphere.linkis.httpclient.response.impl.DefaultHttpResult
+import com.webank.wedatasphere.linkis.httpclient.response.{HttpResult, Result}
+import org.apache.commons.io.IOUtils
+import org.apache.commons.lang.StringUtils
+import org.apache.http.impl.cookie.BasicClientCookie
+
+import scala.collection.convert.wrapAsScala._
+
+
+class OriginSSORequestOperation private[request](appName: String) extends SSORequestOperation[HttpAction, HttpResult] with Logging {
+
+  override def requestWithSSO(urlBuilder: SSOUrlBuilderOperation, req: HttpAction): HttpResult = {
+
+    val httpClient = HttpClient.getHttpClient(urlBuilder.getBuiltUrl, appName)
+    urlBuilder match {
+      case urlBuilderOperationImpl: SSOUrlBuilderOperationImpl => val cookies = urlBuilderOperationImpl.getCookies
+        cookies.foreach {
+          case (key, value) =>
+            val basicClientCookie = new BasicClientCookie(key, value)
+            val domain = Utils.tryCatch(new URI(urlBuilder.getBuiltUrl).getHost)(_ => "")
+            basicClientCookie.setDomain(domain)
+            basicClientCookie.setPath("/")
+            basicClientCookie.setExpiryDate(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 24 * 30L))
+            info("Add cookie for get user info " + basicClientCookie.toString)
+            req.addCookie(basicClientCookie)
+        }
+    }
+    Utils.tryFinally({
+      httpClient.execute(req) match {
+        case result: HttpResult => result
+        case result => if (Result.isSuccessResult(result)) {
+          val defaultHttpResult = new DefaultHttpResult
+          defaultHttpResult.set(null, 200, null, null)
+          defaultHttpResult
+        } else throw new AppStandardErrorException(20300, s"Not support Result => ${result.getClass.getName}.")
+      }
+    })(IOUtils.closeQuietly(httpClient))
+  }
+
+}
+
+object OriginSSORequestOperation extends Logging {
+
+  val MAX_ACTIVE_TIME = ByteTimeUtils.timeStringAsMs("15m")
+
+  private val httpClientLastAccessMap = new ConcurrentHashMap[String, Long]
+  private val httpClientMap = new util.HashMap[String, Client]
+
+  Utils.defaultScheduler.scheduleWithFixedDelay(new Runnable {
+    override def run(): Unit = httpClientLastAccessMap.keySet().toArray.foreach {
+      case key: String =>
+        if (System.currentTimeMillis - httpClientLastAccessMap.get(key) >= MAX_ACTIVE_TIME) httpClientMap synchronized {
+          if (httpClientLastAccessMap.containsKey(key)) {
+            httpClientLastAccessMap.remove(key)
+            IOUtils.closeQuietly(httpClientMap.get(key))
+            httpClientMap.remove(key)
+            info(s"SSORequestOperation removed expired key($key).")
+          }
+        }
+    }
+  }, MAX_ACTIVE_TIME, MAX_ACTIVE_TIME, TimeUnit.MILLISECONDS)
+
+  def getHttpClient(urlBuilder: SSOUrlBuilderOperation, appName: String): Client = urlBuilder match {
+    case builder: SSOUrlBuilderOperationImpl =>
+      builder.getCookies.find(_._1 == "bdp-user-ticket-id").foreach { case (_, ticketId) =>
+        val key = getKey(ticketId, appName)
+        if (httpClientMap.containsKey(key) && System.currentTimeMillis - httpClientLastAccessMap.get(key) < MAX_ACTIVE_TIME) {
+          httpClientLastAccessMap.put(key, System.currentTimeMillis)
+          return httpClientMap.get(key)
+        }
+        else httpClientMap synchronized {
+          if (httpClientMap.containsKey(key) && System.currentTimeMillis - httpClientLastAccessMap.get(key) < MAX_ACTIVE_TIME) {
+            httpClientLastAccessMap.put(key, System.currentTimeMillis)
+            return httpClientMap.get(key)
+          } else {
+            if (httpClientMap.containsKey(key)) {
+              httpClientMap.get(key).close()
+            }
+
+            val httpClient = HttpClient.getHttpClient(urlBuilder.getBuiltUrl, appName)
+            httpClientMap.put(key, httpClient)
+            httpClientLastAccessMap.put(key, System.currentTimeMillis)
+            info(s"SSORequestOperation add a new HttpClient for key($key).")
+            return httpClient
+          }
+        }
+      }
+      throw new AppStandardErrorException(20300, "User has not login, please login first.")
+    case _ =>
+      throw new AppStandardErrorException(20300, s"Not support SSOUrlBuilderOperation => ${urlBuilder.getClass.getName}.")
+  }
+
+
+  private def getKey(ticketId: String, appName: String): String = appName + ticketId
+
+}

--- a/dss-standard/sso-standard/origin-sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/origin/request/OriginSSORequestServiceImpl.scala
+++ b/dss-standard/sso-standard/origin-sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/origin/request/OriginSSORequestServiceImpl.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.origin.request
+
+import java.util
+
+import com.webank.wedatasphere.dss.standard.app.sso.request.{SSORequestOperation, SSORequestService}
+import com.webank.wedatasphere.dss.standard.common.service.AppServiceImpl
+import com.webank.wedatasphere.linkis.httpclient.request.HttpAction
+import com.webank.wedatasphere.linkis.httpclient.response.HttpResult
+
+
+class OriginSSORequestServiceImpl extends AppServiceImpl with SSORequestService {
+
+  private val ssoRequestServices = new util.HashMap[String, OriginSSORequestOperation]
+
+  override def createSSORequestOperation(appName: String): SSORequestOperation[HttpAction, HttpResult] = {
+    if(!ssoRequestServices.containsKey(appName)) synchronized {
+      if(!ssoRequestServices.containsKey(appName)) ssoRequestServices.put(appName, new OriginSSORequestOperation(appName))
+    }
+    ssoRequestServices.get(appName)
+  }
+}

--- a/dss-standard/sso-standard/spring-origin-sso-integration-plugin/pom.xml
+++ b/dss-standard/sso-standard/spring-origin-sso-integration-plugin/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>dss</artifactId>
+    <groupId>com.webank.wedatasphere.dss</groupId>
+    <version>1.0.0</version>
+    <relativePath>../../../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>spring-origin-sso-integration-plugin</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.webank.wedatasphere.dss</groupId>
+      <artifactId>dss-sso-integration-standard</artifactId>
+      <version>${dss.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.webank.wedatasphere.dss</groupId>
+      <artifactId>dss-origin-sso-integration-standard</artifactId>
+      <version>${dss.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>${spring.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <version>${spring.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <version>${spring.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/dss-standard/sso-standard/spring-origin-sso-integration-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/origin/filter/spring/SpringOriginSSOPluginFilter.java
+++ b/dss-standard/sso-standard/spring-origin-sso-integration-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/origin/filter/spring/SpringOriginSSOPluginFilter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.origin.filter.spring;
+
+import com.webank.wedatasphere.dss.standard.app.sso.origin.plugin.OriginSSOPluginFilter;
+import com.webank.wedatasphere.dss.standard.app.sso.plugin.filter.UserInterceptor;
+
+import javax.servlet.FilterConfig;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
+
+
+@Component
+public class SpringOriginSSOPluginFilter extends OriginSSOPluginFilter {
+
+    @Override
+    public UserInterceptor getUserInterceptor(FilterConfig filterConfig) {
+        WebApplicationContext webApplicationContext =
+            WebApplicationContextUtils.getRequiredWebApplicationContext(filterConfig.getServletContext());
+        return webApplicationContext.getBean(UserInterceptor.class);
+    }
+}

--- a/dss-standard/sso-standard/sso-integration-standard/pom.xml
+++ b/dss-standard/sso-standard/sso-integration-standard/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>dss</artifactId>
+    <groupId>com.webank.wedatasphere.dss</groupId>
+    <version>1.0.0</version>
+    <relativePath>../../../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>dss-sso-integration-standard</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.webank.wedatasphere.dss</groupId>
+      <artifactId>dss-standard-common</artifactId>
+      <version>${dss.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.webank.wedatasphere.dss</groupId>
+      <artifactId>dss-common</artifactId>
+      <version>${dss.version}</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>scala-compile-first</id>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/SSOIntegrationStandard.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/SSOIntegrationStandard.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso;
+
+import com.webank.wedatasphere.dss.standard.app.sso.builder.SSOBuilderService;
+import com.webank.wedatasphere.dss.standard.app.sso.builder.impl.SSOBuilderServiceImplImpl;
+import com.webank.wedatasphere.dss.standard.app.sso.request.SSORequestService;
+import com.webank.wedatasphere.dss.standard.app.sso.plugin.SSOPluginService;
+import com.webank.wedatasphere.dss.standard.common.core.AppStandard;
+
+
+public interface SSOIntegrationStandard extends AppStandard {
+
+    default SSOBuilderService getSSOBuilderService() {
+        return SSOBuilderServiceImplImpl.getSSOBuilderService();
+    }
+
+    SSORequestService getSSORequestService();
+
+    SSOPluginService getSSOPluginService();
+
+    @Override
+    default String getStandardName() {
+        return "ssoIntegrationStandard";
+    }
+
+    @Override
+    default int getGrade() {
+        return 1;
+    }
+
+    @Override
+    default boolean isNecessary() {
+        return true;
+    }
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/SSOIntegrationStandardFactory.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/SSOIntegrationStandardFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso;
+
+import java.io.Serializable;
+
+public interface SSOIntegrationStandardFactory extends Serializable {
+
+    void init();
+
+    SSOIntegrationStandard getSSOIntegrationStandard();
+
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/Workspace.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/Workspace.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso;
+
+import com.webank.wedatasphere.dss.common.entity.DSSWorkspace;
+import com.webank.wedatasphere.dss.standard.app.sso.builder.SSOUrlBuilderOperation;
+import com.webank.wedatasphere.dss.standard.app.sso.builder.impl.SSOUrlBuilderOperationImpl;
+import com.webank.wedatasphere.dss.standard.app.sso.plugin.SSOIntegrationConf;
+
+
+public class Workspace implements DSSWorkspace {
+
+    protected String workspaceName;
+
+    protected transient SSOUrlBuilderOperation ssoUrlBuilderOperation;
+
+    private String operationStr;
+
+    @Override
+    public String getWorkspaceName() {
+        return this.workspaceName;
+    }
+
+
+    public void setWorkspaceName(String workspaceName) {
+        this.workspaceName = workspaceName;
+    }
+
+
+    public SSOUrlBuilderOperation getSSOUrlBuilderOperation() {
+        if (this.ssoUrlBuilderOperation == null) {
+            this.ssoUrlBuilderOperation = SSOUrlBuilderOperationImpl.restore(operationStr);
+        }
+        return this.ssoUrlBuilderOperation;
+    }
+
+
+    public void setSSOUrlBuilderOperation(SSOUrlBuilderOperation ssoUrlBuilderOperation) {
+        this.ssoUrlBuilderOperation = ssoUrlBuilderOperation;
+        this.operationStr = SSOIntegrationConf.gson().toJson(ssoUrlBuilderOperation);
+    }
+
+    public String getOperationStr() {
+        return operationStr;
+    }
+
+    public void setOperationStr(String operationStr) {
+        this.operationStr = operationStr;
+    }
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/builder/DssMsgBuilderOperation.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/builder/DssMsgBuilderOperation.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.builder;
+
+import com.webank.wedatasphere.dss.standard.common.service.Operation;
+
+import java.util.Map;
+
+
+public interface DssMsgBuilderOperation extends Operation {
+
+    DssMsgBuilderOperation setQueryString(String queryString);
+
+    DssMsgBuilderOperation setParameterMap(Map<String, String[]> parameterMap);
+
+    boolean isDSSMsgRequest();
+
+    DSSMsg getBuiltMsg();
+
+    interface DSSMsg {
+
+        String getRedirectUrl();
+
+        String getWorkspaceName();
+
+        String getDSSUrl();
+
+        String getAppName();
+
+        Map<String, String> getCookies();
+    }
+
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/builder/SSOBuilderService.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/builder/SSOBuilderService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.builder;
+
+
+import com.webank.wedatasphere.dss.standard.common.service.AppService;
+
+
+public interface SSOBuilderService extends AppService {
+
+    SSOUrlBuilderOperation createSSOUrlBuilderOperation();
+
+    DssMsgBuilderOperation createDssMsgBuilderOperation();
+
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/builder/SSOUrlBuilderOperation.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/builder/SSOUrlBuilderOperation.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.builder;
+
+
+import com.webank.wedatasphere.dss.standard.common.exception.AppStandardErrorException;
+import com.webank.wedatasphere.dss.standard.common.service.Operation;
+
+
+public interface SSOUrlBuilderOperation extends Operation {
+
+    SSOUrlBuilderOperation setReqUrl(String reqUrl);
+
+    SSOUrlBuilderOperation setWorkspace(String workspaceName);
+
+    SSOUrlBuilderOperation setDSSUrl(String dssUrl);
+
+    SSOUrlBuilderOperation setAppName(String appConnName);
+
+    SSOUrlBuilderOperation addCookie(String key, String value);
+
+    SSOUrlBuilderOperation redirectTo(String redirectUrl);
+
+    SSOUrlBuilderOperation copy();
+
+    String getBuiltUrl() throws AppStandardErrorException;
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/builder/impl/DSSMsgImpl.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/builder/impl/DSSMsgImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.builder.impl;
+
+import com.webank.wedatasphere.dss.standard.app.sso.builder.DssMsgBuilderOperation.DSSMsg;
+import java.util.Map;
+
+
+public class DSSMsgImpl implements DSSMsg {
+
+    private String redirectUrl;
+    private String workspaceName;
+    private String dssUrl;
+    private String appName;
+    private Map<String, String> cookies;
+
+    @Override
+    public String getRedirectUrl() {
+        return redirectUrl;
+    }
+
+    @Override
+    public String getWorkspaceName() {
+        return workspaceName;
+    }
+
+    @Override
+    public String getDSSUrl() {
+        return dssUrl;
+    }
+
+    @Override
+    public Map<String, String> getCookies() {
+        return cookies;
+    }
+
+    public void setRedirectUrl(String redirectUrl) {
+        this.redirectUrl = redirectUrl;
+    }
+
+    public void setWorkspaceName(String workspaceName) {
+        this.workspaceName = workspaceName;
+    }
+
+    public void setDSSUrl(String dssUrl) {
+        this.dssUrl = dssUrl;
+    }
+
+    @Override
+    public String getAppName() {
+        return appName;
+    }
+
+    public void setAppName(String appName) {
+        this.appName = appName;
+    }
+
+    public void setCookies(Map<String, String> cookies) {
+        this.cookies = cookies;
+    }
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/builder/impl/DssMsgBuilderOperationImpl.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/builder/impl/DssMsgBuilderOperationImpl.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.builder.impl;
+
+import com.webank.wedatasphere.dss.standard.app.sso.builder.DssMsgBuilderOperation;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class DssMsgBuilderOperationImpl implements DssMsgBuilderOperation {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DssMsgBuilderOperationImpl.class);
+
+    private String queryString;
+    private Map<String, String[]> parameterMap;
+
+    @Override
+    public DssMsgBuilderOperation setQueryString(String queryString) {
+        this.queryString = queryString;
+        return this;
+    }
+
+    @Override
+    public DssMsgBuilderOperation setParameterMap(Map<String, String[]> parameterMap) {
+        this.parameterMap = parameterMap;
+        return this;
+    }
+
+    @Override
+    public boolean isDSSMsgRequest() {
+        return parameterMap.containsKey("dssurl");
+    }
+
+    private String getOrNull(String key) {
+        String[] values = parameterMap.get(key);
+        if(values == null || values.length == 0) {
+            return null;
+        } else {
+            return values[0];
+        }
+    }
+
+    @Override
+    public DSSMsg getBuiltMsg() {
+        DSSMsgImpl dssMsg = new DSSMsgImpl();
+        dssMsg.setRedirectUrl(getOrNull("redirect"));
+        dssMsg.setDSSUrl(getOrNull("dssurl"));
+        dssMsg.setWorkspaceName(getOrNull("workspace"));
+        dssMsg.setAppName(getOrNull("appName"));
+        Map<String, String> cookies = new HashMap<>();
+        String cookiesStr = getOrNull("cookies");
+        if(StringUtils.isNotBlank(cookiesStr)) {
+            Arrays.stream(cookiesStr.split(";")).forEach(cookie -> {
+                int index = cookie.indexOf('=');
+                String key = cookie.substring(0, index).trim();
+                String value = cookie.substring(index + 1).trim();
+                cookies.put(key, value);
+            });
+        }
+        LOGGER.info("Set cookies from dssMsg: "+cookies.toString());
+        dssMsg.setCookies(cookies);
+        return dssMsg;
+    }
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/builder/impl/SSOBuilderServiceImplImpl.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/builder/impl/SSOBuilderServiceImplImpl.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.builder.impl;
+
+import com.webank.wedatasphere.dss.standard.app.sso.builder.DssMsgBuilderOperation;
+import com.webank.wedatasphere.dss.standard.app.sso.builder.SSOBuilderService;
+import com.webank.wedatasphere.dss.standard.app.sso.builder.SSOUrlBuilderOperation;
+import com.webank.wedatasphere.dss.standard.common.service.AppServiceImpl;
+
+
+public class SSOBuilderServiceImplImpl extends AppServiceImpl implements SSOBuilderService {
+
+    private static SSOBuilderService ssoBuilderService;
+
+    public static SSOBuilderService getSSOBuilderService() {
+        if(ssoBuilderService == null) {
+            synchronized (SSOBuilderServiceImplImpl.class) {
+                if(ssoBuilderService == null) {
+                    ssoBuilderService = new SSOBuilderServiceImplImpl();
+                }
+            }
+        }
+        return ssoBuilderService;
+    }
+
+    @Override
+    public SSOUrlBuilderOperation createSSOUrlBuilderOperation() {
+        return new SSOUrlBuilderOperationImpl();
+    }
+
+    @Override
+    public DssMsgBuilderOperation createDssMsgBuilderOperation() {
+        return new DssMsgBuilderOperationImpl();
+    }
+
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/builder/impl/SSOUrlBuilderOperationImpl.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/builder/impl/SSOUrlBuilderOperationImpl.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.builder.impl;
+
+import com.webank.wedatasphere.dss.standard.app.sso.builder.SSOUrlBuilderOperation;
+import com.webank.wedatasphere.dss.standard.app.sso.plugin.SSOIntegrationConf;
+import com.webank.wedatasphere.dss.standard.common.exception.AppStandardErrorException;
+import com.webank.wedatasphere.linkis.common.conf.CommonVars;
+import org.apache.commons.lang.StringUtils;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+public class SSOUrlBuilderOperationImpl implements SSOUrlBuilderOperation {
+
+    private static final String SSO_URL_FORMAT = "%s?dssurl=%s&cookies=%s&workspace=%s&appName=%s";
+    private static final String SSO_REDIRECT_URL_FORMAT = "%s?redirect=%s&dssurl=%s&cookies=%s&workspace=%s&appName=%s";
+    private String workspaceName;
+    private Map<String, String> cookies = new HashMap<>();
+    private String dssUrl;
+    private String redirectUrl;
+    private String reqUrl;
+    private String appName;
+
+    protected String urlEncode(String str) throws AppStandardErrorException {
+        try {
+            return URLEncoder.encode(str, "utf-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new AppStandardErrorException(60001, "Encode string failed! string: " + str, e);
+        }
+    }
+
+    @Override
+    public SSOUrlBuilderOperation setWorkspace(String workspaceName) {
+        this.workspaceName = workspaceName;
+        return this;
+    }
+
+    @Override
+    public SSOUrlBuilderOperation addCookie(String key, String value) {
+        cookies.put(key, value);
+        return this;
+    }
+
+    @Override
+    public SSOUrlBuilderOperation redirectTo(String redirectUrl) {
+        this.redirectUrl = redirectUrl;
+        return this;
+    }
+
+    @Override
+    public SSOUrlBuilderOperation setReqUrl(String reqUrl) {
+        this.reqUrl = reqUrl;
+        return this;
+    }
+
+    @Override
+    public SSOUrlBuilderOperation setDSSUrl(String dssUrl) {
+        this.dssUrl = dssUrl;
+        return this;
+    }
+
+    @Override
+    public SSOUrlBuilderOperation setAppName(String appName) {
+        this.appName = appName;
+        return this;
+    }
+
+    @Override
+    public String getBuiltUrl() throws AppStandardErrorException {
+        String cookieStr = cookies.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.getValue())
+            .collect(Collectors.joining(";"));
+        if(StringUtils.isNotBlank(redirectUrl)) {
+            return String.format(SSO_REDIRECT_URL_FORMAT, reqUrl, redirectUrl, urlEncode(dssUrl),
+                urlEncode(cookieStr), workspaceName, appName);
+        } else {
+            return String.format(SSO_URL_FORMAT, reqUrl, urlEncode(dssUrl),
+                urlEncode(cookieStr), workspaceName, appName);
+        }
+    }
+
+    public String getWorkspaceName() {
+        return workspaceName;
+    }
+
+    public Map<String, String> getCookies() {
+        return cookies;
+    }
+
+    public String getDssUrl() {
+        return dssUrl;
+    }
+
+    public String getRedirectUrl() {
+        return redirectUrl;
+    }
+
+    public String getReqUrl() {
+        return reqUrl;
+    }
+
+    public String getAppName() {
+        return appName;
+    }
+
+    @Override
+    public SSOUrlBuilderOperation copy() {
+        SSOUrlBuilderOperationImpl operation = new SSOUrlBuilderOperationImpl();
+        operation.appName = appName;
+        operation.cookies = cookies;
+        operation.dssUrl = dssUrl;
+        operation.redirectUrl = redirectUrl;
+        operation.reqUrl = reqUrl;
+        operation.workspaceName = workspaceName;
+        return operation;
+    }
+
+    public static SSOUrlBuilderOperation restore(String operationStr){
+        Map operationMap = SSOIntegrationConf.gson().fromJson(operationStr, Map.class);
+        SSOUrlBuilderOperationImpl operation = new SSOUrlBuilderOperationImpl();
+        if(operationMap.get("appName") != null) operation.appName = operationMap.get("appName").toString();
+        if(operationMap.get("cookies") != null) operation.cookies = (Map<String, String>) operationMap.get("cookies");
+        if(operationMap.get("dssUrl") != null) operation.dssUrl = operationMap.get("dssUrl").toString();
+        if(operationMap.get("redirectUrl") != null) operation.redirectUrl = operationMap.get("redirectUrl").toString();
+        if(operationMap.get("reqUrl") != null) operation.reqUrl = operationMap.get("reqUrl").toString();
+        if(operationMap.get("workspaceName") != null) operation.workspaceName = operationMap.get("workspaceName").toString();
+        return operation;
+    }
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/AbstractSSOMsgParseOperation.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/AbstractSSOMsgParseOperation.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.plugin;
+
+import com.webank.wedatasphere.dss.standard.app.sso.builder.SSOBuilderService;
+import com.webank.wedatasphere.dss.standard.app.sso.plugin.impl.SSOMsgImpl;
+import com.webank.wedatasphere.dss.standard.app.sso.builder.DssMsgBuilderOperation.DSSMsg;
+import javax.servlet.http.HttpServletRequest;
+
+
+public abstract class AbstractSSOMsgParseOperation implements SSOMsgParseOperation {
+
+    protected SSOBuilderService ssoBuilderService;
+
+    public void setSSOBuilderService(SSOBuilderService ssoBuilderService) {
+        this.ssoBuilderService = ssoBuilderService;
+    }
+
+    @Override
+    public boolean isDssRequest(HttpServletRequest request) {
+        return ssoBuilderService.createDssMsgBuilderOperation().setParameterMap(request.getParameterMap()).isDSSMsgRequest();
+    }
+
+    @Override
+    public DSSMsg getDSSMsg(HttpServletRequest request) {
+        return ssoBuilderService.createDssMsgBuilderOperation()
+            .setParameterMap(request.getParameterMap()).getBuiltMsg();
+    }
+
+    @Override
+    public SSOMsg getSSOMsg(HttpServletRequest request) {
+        DSSMsg dssMsg = getDSSMsg(request);
+        SSOMsg ssoMsg = createSSOMsg();
+        String user = getUser(dssMsg);
+        setSSOMsg(ssoMsg, dssMsg, user);
+        return ssoMsg;
+    }
+
+    protected SSOMsg createSSOMsg() {
+        return new SSOMsgImpl();
+    }
+
+    protected void setSSOMsg(SSOMsg ssoMsg, DSSMsg dssMsg, String user) {
+        SSOMsgImpl ssoMsgImpl = (SSOMsgImpl) ssoMsg;
+        ssoMsgImpl.setRedirectUrl(dssMsg.getRedirectUrl());
+        ssoMsgImpl.setWorkspaceName(dssMsg.getWorkspaceName());
+        ssoMsgImpl.setUser(user);
+    }
+
+    protected abstract String getUser(DSSMsg dssMsg);
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/AbstractWorkspacePlugin.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/AbstractWorkspacePlugin.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.plugin;
+
+import com.webank.wedatasphere.dss.standard.app.sso.builder.DssMsgBuilderOperation.DSSMsg;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+
+
+public abstract class AbstractWorkspacePlugin implements WorkspacePlugin {
+
+    private DssMsgCacheOperation dssMsgCacheOperation;
+
+    public void setDssMsgCacheOperation(DssMsgCacheOperation dssMsgCacheOperation) {
+        this.dssMsgCacheOperation = dssMsgCacheOperation;
+    }
+
+    @Override
+    public String getWorkspaceName(HttpServletRequest req) {
+        return dssMsgCacheOperation.getWorkspaceInSession(req);
+    }
+
+    @Override
+    public List<String> getAllUsers(HttpServletRequest req) {
+        DSSMsg dssMsg = dssMsgCacheOperation.getDSSMsgInSession(req);
+        return getAllUsers(dssMsg);
+    }
+
+    protected abstract List<String> getAllUsers(DSSMsg dssMsg);
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/DssMsgCacheOperation.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/DssMsgCacheOperation.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.plugin;
+
+import com.webank.wedatasphere.dss.standard.common.service.Operation;
+import com.webank.wedatasphere.dss.standard.app.sso.builder.DssMsgBuilderOperation.DSSMsg;
+import javax.servlet.http.HttpServletRequest;
+
+
+public interface DssMsgCacheOperation extends Operation {
+
+    void setWorkspaceToSession(HttpServletRequest req, String workspaceName);
+
+    String getWorkspaceInSession(HttpServletRequest req);
+
+    DSSMsg getDSSMsgInSession(HttpServletRequest request);
+
+    void setDSSMsgToSession(DSSMsg dssMsg, HttpServletRequest request);
+
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/SSOMsg.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/SSOMsg.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.plugin;
+
+
+public interface SSOMsg {
+
+    String getRedirectUrl();
+
+    String getWorkspaceName();
+
+    String getUser();
+
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/SSOMsgParseOperation.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/SSOMsgParseOperation.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.plugin;
+
+import com.webank.wedatasphere.dss.standard.common.service.Operation;
+import com.webank.wedatasphere.dss.standard.app.sso.builder.DssMsgBuilderOperation.DSSMsg;
+import javax.servlet.http.HttpServletRequest;
+
+
+public interface SSOMsgParseOperation extends Operation {
+
+    boolean isDssRequest(HttpServletRequest request);
+
+    DSSMsg getDSSMsg(HttpServletRequest request);
+
+    SSOMsg getSSOMsg(HttpServletRequest request);
+
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/SSOPluginService.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/SSOPluginService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.plugin;
+
+import com.webank.wedatasphere.dss.standard.app.sso.builder.SSOBuilderService;
+import com.webank.wedatasphere.dss.standard.common.service.AppService;
+import java.io.Closeable;
+
+
+public interface SSOPluginService extends AppService, Closeable {
+
+    void setSSOBuilderService(SSOBuilderService ssoBuilderService);
+
+    SSOMsgParseOperation createSSOMsgParseOperation();
+
+    WorkspacePlugin createWorkspacePluginOperation();
+
+    default DssMsgCacheOperation createDssMsgCacheOperation() {
+        return DssMsgCacheOperationImpl.getDssMsgCacheOperation();
+    }
+
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/WorkspacePlugin.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/WorkspacePlugin.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.plugin;
+
+import com.webank.wedatasphere.dss.standard.common.service.Operation;
+
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+
+
+public interface WorkspacePlugin extends Operation {
+
+    List<String> getAllUsers(HttpServletRequest req);
+
+    String getWorkspaceName(HttpServletRequest req);
+
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/filter/DSSInternalUserInterceptor.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/filter/DSSInternalUserInterceptor.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.plugin.filter;
+
+import com.webank.wedatasphere.dss.standard.app.sso.builder.DssMsgBuilderOperation.DSSMsg;
+import javax.servlet.http.HttpServletRequest;
+
+
+public interface DSSInternalUserInterceptor extends UserInterceptor {
+
+    HttpServletRequest addCookiesToRequest(DSSMsg dssMsg, HttpServletRequest req);
+
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/filter/HttpRequestUserInterceptor.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/filter/HttpRequestUserInterceptor.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.plugin.filter;
+
+import javax.servlet.http.HttpServletRequest;
+
+
+public interface HttpRequestUserInterceptor extends UserInterceptor {
+
+    HttpServletRequest addUserToRequest(String user, HttpServletRequest req);
+
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/filter/HttpSessionUserInterceptor.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/filter/HttpSessionUserInterceptor.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.plugin.filter;
+
+import javax.servlet.http.HttpServletRequest;
+
+
+public interface HttpSessionUserInterceptor extends UserInterceptor {
+
+    void addUserToSession(String user, HttpServletRequest req);
+
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/filter/SSOPluginFilter.scala
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/filter/SSOPluginFilter.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.plugin.filter
+
+import com.webank.wedatasphere.dss.standard.app.sso.SSOIntegrationStandard
+import javax.servlet._
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+import org.apache.commons.lang.StringUtils
+
+
+abstract class SSOPluginFilter extends Filter {
+
+  private var userInterceptor: UserInterceptor = _
+
+  override def init(filterConfig: FilterConfig): Unit = {
+    userInterceptor = getUserInterceptor(filterConfig)
+    getSSOIntegrationStandard.init()
+  }
+
+  def info(str: String): Unit
+
+  protected def getUserInterceptor(filterConfig: FilterConfig): UserInterceptor
+
+  protected def getSSOIntegrationStandard: SSOIntegrationStandard
+
+  override def doFilter(servletRequest: ServletRequest, servletResponse: ServletResponse,
+                        filterChain: FilterChain): Unit = {
+    val req = servletRequest.asInstanceOf[HttpServletRequest]
+    val resp = servletResponse.asInstanceOf[HttpServletResponse]
+    val ssoPluginService = getSSOIntegrationStandard.getSSOPluginService
+    val dssMsg = ssoPluginService.createSSOMsgParseOperation().getDSSMsg(req)
+    if (ssoPluginService.createSSOMsgParseOperation.isDssRequest(req)) {
+      val (redirectUrl, workspaceName, wrappedReq) = if(!userInterceptor.isUserExistInSession(req)) {
+        val ssoMsg = ssoPluginService.createSSOMsgParseOperation.getSSOMsg(req)
+        val username = ssoMsg.getUser
+        val wrappedReq = userInterceptor match {
+          case interceptor: HttpSessionUserInterceptor =>
+            interceptor.addUserToSession(username, req)
+            req
+          case interceptor: HttpRequestUserInterceptor => interceptor.addUserToRequest(username, req)
+          case interceptor: DSSInternalUserInterceptor => interceptor.addCookiesToRequest(dssMsg, req)
+        }
+        if(wrappedReq != req) {
+          wrappedReq.getCookies.foreach(resp.addCookie)
+        }
+        info(s"DSS User: $username succeed to login. and wrappedReq cookies is "+wrappedReq.getCookies.toString)
+        (ssoMsg.getRedirectUrl, ssoMsg.getWorkspaceName, wrappedReq)
+      } else {
+        (dssMsg.getRedirectUrl, dssMsg.getWorkspaceName, req)
+      }
+      val workspaceOperation = ssoPluginService.createDssMsgCacheOperation()
+      if(workspaceName != workspaceOperation.getWorkspaceInSession(req)) {
+        info(s"Set DSS workspace to: $workspaceName.")
+        workspaceOperation.setWorkspaceToSession(req, workspaceName)
+      }
+      if(workspaceOperation.getDSSMsgInSession(req) == null) {
+        workspaceOperation.setDSSMsgToSession(dssMsg, req)
+      }
+      if(StringUtils.isNotBlank(redirectUrl)) resp.sendRedirect(redirectUrl)
+      else filterChain.doFilter(wrappedReq, servletResponse)
+    } else {
+      filterChain.doFilter(servletRequest, servletResponse)
+    }
+  }
+
+  override def destroy(): Unit = {}
+
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/filter/UserInterceptor.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/filter/UserInterceptor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.plugin.filter;
+
+import javax.servlet.http.HttpServletRequest;
+
+
+public interface UserInterceptor {
+
+    boolean isUserExistInSession(HttpServletRequest req);
+
+    String getUser(HttpServletRequest req);
+
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/impl/SSOMsgImpl.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/plugin/impl/SSOMsgImpl.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.plugin.impl;
+
+import com.webank.wedatasphere.dss.standard.app.sso.plugin.SSOMsg;
+
+
+public class SSOMsgImpl implements SSOMsg {
+
+    private String redirectUrl;
+    private String user;
+    private String workspaceName;
+
+    @Override
+    public String getRedirectUrl() {
+        return redirectUrl;
+    }
+
+    public void setRedirectUrl(String redirectUrl) {
+        this.redirectUrl = redirectUrl;
+    }
+
+    @Override
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    @Override
+    public String getWorkspaceName() {
+        return workspaceName;
+    }
+
+    public void setWorkspaceName(String workspaceName) {
+        this.workspaceName = workspaceName;
+    }
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/request/SSORequestOperation.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/request/SSORequestOperation.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.request;
+
+import com.webank.wedatasphere.dss.standard.common.exception.AppStandardErrorException;
+import com.webank.wedatasphere.dss.standard.common.service.Operation;
+import com.webank.wedatasphere.dss.standard.app.sso.builder.SSOUrlBuilderOperation;
+
+
+public interface SSORequestOperation<T, R> extends Operation {
+
+    R requestWithSSO(SSOUrlBuilderOperation urlBuilder, T req) throws AppStandardErrorException;
+
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/request/SSORequestService.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/sso/request/SSORequestService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.request;
+
+
+import com.webank.wedatasphere.dss.standard.common.service.AppService;
+
+
+public interface SSORequestService extends AppService {
+
+    SSORequestOperation createSSORequestOperation(String appName);
+
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/sso/utils/SSOHelper.java
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/sso/utils/SSOHelper.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.sso.utils;
+
+import com.webank.wedatasphere.dss.standard.app.sso.Workspace;
+import com.webank.wedatasphere.dss.standard.app.sso.builder.SSOUrlBuilderOperation;
+import com.webank.wedatasphere.dss.standard.app.sso.builder.impl.SSOUrlBuilderOperationImpl;
+import com.webank.wedatasphere.linkis.common.conf.Configuration;
+import java.util.Arrays;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+
+public class SSOHelper {
+
+    public static Workspace getWorkspace(HttpServletRequest request){
+        Cookie[] cookies = request.getCookies();
+        Cookie workspaceCookie = Arrays.stream(cookies).
+                filter(cookie -> "workspaceId".equals(cookie.getName())).findAny().orElse(null);
+        Workspace workspace = new Workspace();
+        if (workspaceCookie != null) {
+            workspace.setWorkspaceName(workspaceCookie.getValue());
+        }
+        SSOUrlBuilderOperation ssoUrlBuilderOperation = new SSOUrlBuilderOperationImpl();
+        Arrays.stream(cookies).forEach(cookie -> ssoUrlBuilderOperation.addCookie(cookie.getName(), cookie.getValue()));
+        ssoUrlBuilderOperation.setDSSUrl(Configuration.GATEWAY_URL().getValue());
+        ssoUrlBuilderOperation.setWorkspace(workspace.getWorkspaceName());
+        workspace.setSSOUrlBuilderOperation(ssoUrlBuilderOperation);
+        return workspace;
+    }
+
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/plugin/DssMsgCacheOperationImpl.scala
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/plugin/DssMsgCacheOperationImpl.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.plugin
+
+import java.lang
+import java.lang.reflect.Type
+
+import com.google.gson.{GsonBuilder, JsonElement, JsonPrimitive, JsonSerializationContext, JsonSerializer}
+import com.webank.wedatasphere.dss.standard.app.sso.builder.DssMsgBuilderOperation
+import com.webank.wedatasphere.dss.standard.app.sso.builder.DssMsgBuilderOperation.DSSMsg
+import com.webank.wedatasphere.dss.standard.app.sso.builder.impl.DSSMsgImpl
+import javax.servlet.http.HttpServletRequest
+
+
+class DssMsgCacheOperationImpl private() extends DssMsgCacheOperation {
+
+  override def setWorkspaceToSession(req: HttpServletRequest, workspaceName: String): Unit =
+    getDSSMsgInSession(req) match {
+      case dssMsg: DSSMsgImpl => dssMsg.setWorkspaceName(workspaceName)
+      case _ =>
+    }
+
+  override def getWorkspaceInSession(req: HttpServletRequest): String =
+    getDSSMsgInSession(req) match {
+      case dssMsg: DSSMsgImpl => dssMsg.getWorkspaceName
+      case _ => null
+    }
+
+  override def getDSSMsgInSession(request: HttpServletRequest): DssMsgBuilderOperation.DSSMsg =
+    request.getSession.getAttribute(DssMsgCacheOperationImpl.DSS_MSG_KEY) match {
+      case dssMsg: DSSMsgImpl => dssMsg
+      case _ => null
+    }
+
+  override def setDSSMsgToSession(dssMsg: DssMsgBuilderOperation.DSSMsg, request: HttpServletRequest): Unit = {
+    val newDSSMsg = dssMsg match {
+      case dss: DSSMsgImpl =>
+        dss.setRedirectUrl(null)
+        dss
+      case dss: DSSMsg =>
+        val dssMsg1 = new DSSMsgImpl
+        dssMsg1.setCookies(dss.getCookies)
+        dssMsg1.setDSSUrl(dss.getDSSUrl)
+        dssMsg1.setWorkspaceName(dss.getWorkspaceName)
+        dssMsg1
+    }
+    request.getSession.setAttribute(DssMsgCacheOperationImpl.DSS_MSG_KEY, newDSSMsg)
+  }
+}
+object DssMsgCacheOperationImpl {
+  private val DSS_MSG_KEY = "dss_msg_key"
+
+  private val dssMsgCacheOperation = new DssMsgCacheOperationImpl
+
+  def getDssMsgCacheOperation: DssMsgCacheOperation = dssMsgCacheOperation
+}

--- a/dss-standard/sso-standard/sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/plugin/SSOIntegrationConf.scala
+++ b/dss-standard/sso-standard/sso-integration-standard/src/main/scala/com/webank/wedatasphere/dss/standard/app/sso/plugin/SSOIntegrationConf.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.sso.plugin
+
+import java.lang
+import java.lang.reflect.Type
+
+import com.google.gson.{GsonBuilder, JsonElement, JsonPrimitive, JsonSerializationContext, JsonSerializer}
+
+
+object SSOIntegrationConf {
+  implicit val gson = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").serializeNulls
+    .registerTypeAdapter(classOf[java.lang.Double], new JsonSerializer[java.lang.Double] {
+      override def serialize(t: lang.Double, `type`: Type, jsonSerializationContext: JsonSerializationContext): JsonElement =
+        if(t == t.longValue()) new JsonPrimitive(t.longValue()) else new JsonPrimitive(t)
+    }).create
+}

--- a/dss-standard/structure-standard/dss-project-plugin/pom.xml
+++ b/dss-standard/structure-standard/dss-project-plugin/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>dss</artifactId>
+    <groupId>com.webank.wedatasphere.dss</groupId>
+    <version>1.0.0</version>
+    <relativePath>../../../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>dss-project-plugin</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.webank.wedatasphere.dss</groupId>
+      <artifactId>dss-origin-sso-integration-standard</artifactId>
+      <version>${dss.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/dss-standard/structure-standard/dss-project-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/ProjectAuth.java
+++ b/dss-standard/structure-standard/dss-project-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/ProjectAuth.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project.plugin;
+
+import java.util.List;
+
+
+public interface ProjectAuth {
+
+    String getWorkspaceName();
+
+    String getProjectId();
+
+    String getProjectName();
+
+    List<String> getEditUsers();
+
+    List<String> getAccessUsers();
+
+    List<String> getExecuteUsers();
+
+    default List<String> getDeleteUsers() {
+        return getEditUsers();
+    }
+
+}

--- a/dss-standard/structure-standard/dss-project-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/ProjectCooperationPlugin.java
+++ b/dss-standard/structure-standard/dss-project-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/ProjectCooperationPlugin.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project.plugin;
+
+import javax.servlet.http.HttpServletRequest;
+
+
+public interface ProjectCooperationPlugin {
+
+    ProjectAuth getProjectAuth(HttpServletRequest request, String projectId);
+
+    ProjectAuth getProjectAuthByName(HttpServletRequest request, String projectName);
+
+}

--- a/dss-standard/structure-standard/dss-project-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/ProjectPlugin.java
+++ b/dss-standard/structure-standard/dss-project-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/ProjectPlugin.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project.plugin;
+
+import com.webank.wedatasphere.dss.standard.app.sso.SSOIntegrationStandard;
+import com.webank.wedatasphere.dss.standard.app.sso.origin.OriginSSOIntegrationStandardFactory;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+
+public interface ProjectPlugin {
+
+    //TODO 如果一个用户从dss空间进入到qualitis建立工程，添加一个是否是创建工程的请求，添加一个开关参数，是否允许用户建工程
+    List<String> getProjects(HttpServletRequest request);
+
+    default <T> List<T> filterProjects(List<T> projects, HttpServletRequest request,
+                                        Function<T, String> getProjectId) {
+        SSOIntegrationStandard ssoIntegrationStandard = new OriginSSOIntegrationStandardFactory().getSSOIntegrationStandard();
+        if(!ssoIntegrationStandard.getSSOPluginService().createSSOMsgParseOperation().isDssRequest(request)) {
+            return projects;
+        }
+        List<String> projectList = getProjects(request);
+        if(projectList == null) {
+            return new ArrayList<>();
+        }
+        List<T> filteredList =  projects.stream().filter(t -> projectList.contains(getProjectId.apply(t)))
+            .collect(Collectors.toList());
+        return filteredList;
+    }
+
+}

--- a/dss-standard/structure-standard/dss-project-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/filter/AbstractProjectAuthInterceptor.java
+++ b/dss-standard/structure-standard/dss-project-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/filter/AbstractProjectAuthInterceptor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project.plugin.filter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.webank.wedatasphere.dss.standard.app.structure.project.plugin.ProjectAuth;
+import com.webank.wedatasphere.dss.standard.app.sso.origin.client.HttpClient;
+import com.webank.wedatasphere.dss.standard.common.exception.AppStandardWarnException;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+
+
+public abstract class AbstractProjectAuthInterceptor implements ProjectAuthInterceptor {
+
+    private List<String> projectUris = new ArrayList<>();
+
+    @Override
+    public boolean isProjectRequest(HttpServletRequest request) {
+        String requestUri = request.getRequestURI();
+        return projectUris.stream().anyMatch(requestUri::matches);
+    }
+
+    protected void addProjectUri(String projectUri) {
+        projectUris.add(projectUri);
+    }
+
+    @Override
+    public String getForbiddenMsg(ProjectAuth projectAuth, ProjectRequestType projectRequestType,
+                                  HttpServletRequest request) {
+        String message = "You have no permission to " + projectRequestType.toString().toLowerCase() +
+            " the content of project " + projectAuth.getProjectName();
+        Object returnObj = getForbiddenMsg(message);
+        if(returnObj instanceof String) {
+            return (String) returnObj;
+        } else {
+            try {
+                return HttpClient.objectMapper().writeValueAsString(returnObj);
+            } catch (JsonProcessingException e) {
+                throw new AppStandardWarnException(50002, "Serialize object to string failed! Object: " + returnObj, e);
+            }
+        }
+    }
+
+    protected abstract Object getForbiddenMsg(String message);
+}

--- a/dss-standard/structure-standard/dss-project-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/filter/ProjectAuthInterceptor.java
+++ b/dss-standard/structure-standard/dss-project-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/filter/ProjectAuthInterceptor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project.plugin.filter;
+
+import com.webank.wedatasphere.dss.standard.app.structure.project.plugin.ProjectAuth;
+
+import javax.servlet.http.HttpServletRequest;
+
+
+public interface ProjectAuthInterceptor {
+
+    boolean isProjectRequest(HttpServletRequest request);
+
+    String getProjectId(HttpServletRequest request);
+
+    String getProjectName(HttpServletRequest request);
+
+    ProjectRequestType getProjectRequestType(HttpServletRequest request);
+
+    String getForbiddenMsg(ProjectAuth projectAuth, ProjectRequestType projectRequestType,
+                           HttpServletRequest request);
+
+}

--- a/dss-standard/structure-standard/dss-project-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/filter/ProjectRequestType.java
+++ b/dss-standard/structure-standard/dss-project-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/filter/ProjectRequestType.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project.plugin.filter;
+
+
+public enum ProjectRequestType {
+    Edit, Access, Delete, Execute
+}

--- a/dss-standard/structure-standard/dss-project-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/origin/ProjectAuthImpl.java
+++ b/dss-standard/structure-standard/dss-project-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/origin/ProjectAuthImpl.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project.plugin.origin;
+
+import com.webank.wedatasphere.dss.standard.app.structure.project.plugin.ProjectAuth;
+
+import java.util.List;
+
+
+public class ProjectAuthImpl implements ProjectAuth {
+
+    private String workspaceName;
+    private String projectId;
+    private String projectName;
+    private List<String> editUsers;
+    private List<String> accessUsers;
+    private List<String> deleteUsers;
+    private List<String> executeUsers;
+
+    @Override
+    public String getWorkspaceName() {
+        return workspaceName;
+    }
+
+    public void setWorkspaceName(String workspaceName) {
+        this.workspaceName = workspaceName;
+    }
+
+    @Override
+    public String getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(String projectId) {
+        this.projectId = projectId;
+    }
+
+    @Override
+    public String getProjectName() {
+        return projectName;
+    }
+
+    public void setProjectName(String projectName) {
+        this.projectName = projectName;
+    }
+
+    @Override
+    public List<String> getEditUsers() {
+        return editUsers;
+    }
+
+    public void setEditUsers(List<String> editUsers) {
+        this.editUsers = editUsers;
+    }
+
+    @Override
+    public List<String> getAccessUsers() {
+        return accessUsers;
+    }
+
+    @Override
+    public List<String> getExecuteUsers() {
+        return executeUsers;
+    }
+
+    public void setExecuteUsers(List<String> executeUsers) {
+        this.executeUsers = executeUsers;
+    }
+
+    public void setAccessUsers(List<String> accessUsers) {
+        this.accessUsers = accessUsers;
+    }
+
+    @Override
+    public List<String> getDeleteUsers() {
+        if(deleteUsers == null || deleteUsers.isEmpty()) {
+            return editUsers;
+        }
+        return deleteUsers;
+    }
+
+    public void setDeleteUsers(List<String> deleteUsers) {
+        this.deleteUsers = deleteUsers;
+    }
+
+    @Override
+    public String toString() {
+        return "ProjectAuthImpl(" +
+            "workspaceName='" + workspaceName + '\'' +
+            ", projectId='" + projectId + '\'' +
+            ", projectName='" + projectName + '\'' +
+            ", editUsers=" + editUsers +
+            ", accessUsers=" + accessUsers +
+            ", deleteUsers=" + deleteUsers +
+            ')';
+    }
+}

--- a/dss-standard/structure-standard/dss-project-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/conf/ProjectCooperateConfiguration.scala
+++ b/dss-standard/structure-standard/dss-project-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/conf/ProjectCooperateConfiguration.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project.plugin.conf
+
+import com.webank.wedatasphere.linkis.common.conf.{CommonVars, TimeType}
+
+
+object ProjectCooperateConfiguration {
+
+  val EXPIRE_PROJECT_AUTH_TIMEOUT = CommonVars("wds.dss.project.auth.timeout", new TimeType("10m"))
+  val EXPIRE_PROJECT_AUTH_SCAN_INTERVAL = CommonVars("wds.dss.project.auth.scan.interval", new TimeType("5m"))
+
+}

--- a/dss-standard/structure-standard/dss-project-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/filter/ProjectCooperationFilter.scala
+++ b/dss-standard/structure-standard/dss-project-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/filter/ProjectCooperationFilter.scala
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project.plugin.filter
+
+import java.util
+import java.util.concurrent.TimeUnit
+
+import com.webank.wedatasphere.dss.standard.app.sso.SSOIntegrationStandard
+import com.webank.wedatasphere.dss.standard.app.sso.origin.OriginSSOIntegrationStandardFactory
+import com.webank.wedatasphere.dss.standard.app.sso.plugin.filter.UserInterceptor
+import com.webank.wedatasphere.dss.standard.app.structure.project.plugin.conf.ProjectCooperateConfiguration
+import com.webank.wedatasphere.dss.standard.app.structure.project.plugin.filter.ProjectRequestType.{Access, Delete, Edit, Execute}
+import com.webank.wedatasphere.dss.standard.app.structure.project.plugin.{ProjectAuth, ProjectCooperationPlugin}
+import com.webank.wedatasphere.linkis.common.conf.Configuration
+import com.webank.wedatasphere.linkis.common.utils.{Logging, Utils}
+import com.webank.wedatasphere.linkis.httpclient.exception.HttpClientResultException
+import javax.servlet._
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+import org.apache.commons.lang.StringUtils
+
+
+abstract class ProjectCooperationFilter extends Filter with Logging {
+
+  protected var projectAuthInterceptor: ProjectAuthInterceptor = _
+  protected var userInterceptor: UserInterceptor = _
+  protected var projectCooperationPlugin: ProjectCooperationPlugin = _
+  private val cachedProjectAuthsWithId = new util.HashMap[String, TimeoutProjectAuth]()
+  private val cachedProjectAuthsWithName = new util.HashMap[String, TimeoutProjectAuth]()
+  private val ignoreProjectWithId = new util.ArrayList[String]()
+  private val ignoreProjectWithName = new util.ArrayList[String]()
+
+  override def init(filterConfig: FilterConfig): Unit = {
+    projectAuthInterceptor = getProjectAuthInterceptor(filterConfig)
+    userInterceptor = getUserAuthInterceptor(filterConfig)
+    projectCooperationPlugin = getProjectCooperationPlugin(filterConfig)
+  }
+
+  protected def getProjectAuthInterceptor(filterConfig: FilterConfig): ProjectAuthInterceptor
+  protected def getUserAuthInterceptor(filterConfig: FilterConfig): UserInterceptor
+  protected def getProjectCooperationPlugin(filterConfig: FilterConfig): ProjectCooperationPlugin
+
+  override def doFilter(servletRequest: ServletRequest, servletResponse: ServletResponse,
+                        filterChain: FilterChain): Unit = {
+    val req = servletRequest.asInstanceOf[HttpServletRequest]
+    val uri = req.getRequestURI
+    val ssoIntegrationStandard:SSOIntegrationStandard =new OriginSSOIntegrationStandardFactory().getSSOIntegrationStandard
+    if(ssoIntegrationStandard.getSSOPluginService
+      .createDssMsgCacheOperation().getWorkspaceInSession(req) == null) {
+      info(s"Request $uri has no relation with DSS, ignore it.")
+      filterChain.doFilter(servletRequest, servletResponse)
+      return
+    }
+    val resp = servletResponse.asInstanceOf[HttpServletResponse]
+    if(!projectAuthInterceptor.isProjectRequest(req)) {
+      info(s"Request $uri is not a project request, ignore it.")
+      filterChain.doFilter(req, resp)
+      return
+    }
+    val projectId = projectAuthInterceptor.getProjectId(req)
+    if(ignoreProjectWithId.contains(projectId)) {
+      info(s"The project $projectId is not a DSS project, ignore it, request is $uri.")
+      filterChain.doFilter(req, resp)
+      return
+    }
+    val projectAuth = if(StringUtils.isNotBlank(projectId)) {
+      getProjectAuthById(req, projectId)
+    } else {
+      val projectName = projectAuthInterceptor.getProjectName(req)
+      // If this request cannot get the projectId or projectName, ignore it.
+      if(StringUtils.isBlank(projectName) || ignoreProjectWithName.contains(projectName)) {
+        info(s"This request $uri cannot get the projectId or projectName, ignore it.")
+        filterChain.doFilter(req, resp)
+        return
+      }
+      getProjectAuthByName(req, projectName)
+    }
+    if(projectAuth == null) {
+      filterChain.doFilter(req, resp)
+      return
+    }
+    val projectRequestType = projectAuthInterceptor.getProjectRequestType(req)
+    debug(s"RequestURI: $uri, ProjectRequestType: $projectRequestType, ProjectAuth: $projectAuth.")
+    val user = userInterceptor.getUser(req)
+    val passed = projectRequestType match {
+      case Edit => projectAuth.getEditUsers.contains(user)
+      case Access => projectAuth.getAccessUsers.contains(user)
+      case Delete => projectAuth.getDeleteUsers.contains(user)
+      case Execute => projectAuth.getDeleteUsers.contains(user)
+    }
+    if(passed) {
+      info(s"Cooperation Project request $uri has passed auth validation.")
+      filterChain.doFilter(req, resp)
+    } else {
+      val msg = projectAuthInterceptor.getForbiddenMsg(projectAuth, projectRequestType, req)
+      info(s"Cooperation Project request $uri has been failed with auth validation.")
+      resp.getOutputStream.write(msg.getBytes(Configuration.BDP_ENCODING.getValue))
+      resp.setStatus(403)
+      resp.getOutputStream.flush()
+    }
+  }
+
+  protected def getProjectAuthById(req: HttpServletRequest, projectId: String): ProjectAuth =
+    getProjectAuth(projectId, cachedProjectAuthsWithId,
+      projectCooperationPlugin.getProjectAuth(req, projectId), ignoreProjectWithId)
+
+  protected def getProjectAuthByName(req: HttpServletRequest, projectName: String): ProjectAuth =
+    getProjectAuth(projectName, cachedProjectAuthsWithName,
+      projectCooperationPlugin.getProjectAuthByName(req, projectName), ignoreProjectWithName)
+
+  private def getProjectAuth(key: String,
+                               map: util.HashMap[String, TimeoutProjectAuth],
+                               getNewProjectAuth: => ProjectAuth,
+                               list: util.ArrayList[String]): ProjectAuth = {
+    var timeoutProjectAuth = map.get(key)
+    if(timeoutProjectAuth == null || timeoutProjectAuth.isTimeout) {
+      key.intern().synchronized {
+        timeoutProjectAuth = map.get(key)
+        if(timeoutProjectAuth == null || timeoutProjectAuth.isTimeout) {
+          val projectAuth = Utils.tryCatch(getNewProjectAuth) {
+            case t: HttpClientResultException =>
+              if(t.getDesc.contains("not exists")) {
+                list.add(key)
+                return null
+              } else throw t
+            case t: Throwable => throw t
+          }
+          map.put(key, TimeoutProjectAuth(projectAuth))
+        }
+      }
+    }
+    map.get(key).projectAuth
+  }
+
+  override def destroy(): Unit = {}
+
+  private case class TimeoutProjectAuth(createTime: Long, projectAuth: ProjectAuth) {
+    def isTimeout: Boolean = System.currentTimeMillis() - createTime > ProjectCooperateConfiguration.EXPIRE_PROJECT_AUTH_TIMEOUT.getValue.toLong
+  }
+  private object TimeoutProjectAuth {
+    def apply(projectAuth: ProjectAuth): TimeoutProjectAuth =
+      new TimeoutProjectAuth(System.currentTimeMillis(), projectAuth)
+  }
+
+  Utils.defaultScheduler.scheduleAtFixedRate(new Runnable {
+    override def run(): Unit = {
+      cachedProjectAuthsWithId.keySet().toArray
+        .foreach{ case k: String => if(cachedProjectAuthsWithId.get(k).isTimeout) cachedProjectAuthsWithId.remove(k)}
+      cachedProjectAuthsWithName.keySet().toArray
+        .foreach{ case k: String => if(cachedProjectAuthsWithName.get(k).isTimeout) cachedProjectAuthsWithName.remove(k)}
+    }
+  } , ProjectCooperateConfiguration.EXPIRE_PROJECT_AUTH_SCAN_INTERVAL.getValue.toLong, ProjectCooperateConfiguration.EXPIRE_PROJECT_AUTH_SCAN_INTERVAL.getValue.toLong, TimeUnit.MILLISECONDS)
+
+}

--- a/dss-standard/structure-standard/dss-role-plugin/pom.xml
+++ b/dss-standard/structure-standard/dss-role-plugin/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>dss</artifactId>
+    <groupId>com.webank.wedatasphere.dss</groupId>
+    <version>1.0.0</version>
+    <relativePath>../../../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>dss-role-plugin</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.webank.wedatasphere.dss</groupId>
+      <artifactId>dss-origin-sso-integration-standard</artifactId>
+      <version>${dss.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/dss-standard/structure-standard/dss-role-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/plugin/role/DSSUserRoles.java
+++ b/dss-standard/structure-standard/dss-role-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/plugin/role/DSSUserRoles.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.plugin.role;
+
+import java.util.List;
+
+
+public interface DSSUserRoles {
+
+    List<String> getRoles();
+
+    String getWorkspaceName();
+
+    String getUser();
+
+}

--- a/dss-standard/structure-standard/dss-role-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/plugin/role/RolePlugin.java
+++ b/dss-standard/structure-standard/dss-role-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/plugin/role/RolePlugin.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.plugin.role;
+
+import com.webank.wedatasphere.dss.standard.app.structure.plugin.role.impl.OriginRolePlugin;
+
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+
+
+public interface RolePlugin {
+
+    DSSUserRoles getRoles(HttpServletRequest request);
+
+    List<String> getUsers(HttpServletRequest request, String role);
+
+    static RolePlugin getRolePlugin() {
+        return OriginRolePlugin.getRolePlugin();
+    }
+
+}

--- a/dss-standard/structure-standard/dss-role-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/plugin/role/impl/DSSUserRolesImpl.java
+++ b/dss-standard/structure-standard/dss-role-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/plugin/role/impl/DSSUserRolesImpl.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.plugin.role.impl;
+
+import com.webank.wedatasphere.dss.standard.app.structure.plugin.role.DSSUserRoles;
+
+import java.util.List;
+
+
+public class DSSUserRolesImpl implements DSSUserRoles {
+
+    private List<String> roles;
+    private String workspaceName;
+    private String user;
+
+    public void setRoles(List<String> roles) {
+        this.roles = roles;
+    }
+
+    public void setWorkspaceName(String workspaceName) {
+        this.workspaceName = workspaceName;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    @Override
+    public List<String> getRoles() {
+        return roles;
+    }
+
+    @Override
+    public String getWorkspaceName() {
+        return workspaceName;
+    }
+
+    @Override
+    public String getUser() {
+        return user;
+    }
+}

--- a/dss-standard/structure-standard/dss-role-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/plugin/role/impl/OriginRolePlugin.scala
+++ b/dss-standard/structure-standard/dss-role-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/plugin/role/impl/OriginRolePlugin.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.plugin.role.impl
+
+import java.util
+
+import com.webank.wedatasphere.dss.standard.app.sso.SSOIntegrationStandard
+import com.webank.wedatasphere.dss.standard.app.sso.origin.OriginSSOIntegrationStandardFactory
+import com.webank.wedatasphere.dss.standard.app.sso.origin.client.HttpClient
+import com.webank.wedatasphere.dss.standard.app.structure.plugin.role.{DSSUserRoles, RolePlugin}
+import javax.servlet.http.HttpServletRequest
+
+
+class OriginRolePlugin private() extends RolePlugin {
+  val ssoIntegrationStandard:SSOIntegrationStandard =new OriginSSOIntegrationStandardFactory().getSSOIntegrationStandard
+
+  override def getRoles(request: HttpServletRequest): DSSUserRoles = {
+    val dssMsg = ssoIntegrationStandard.getSSOPluginService
+      .createDssMsgCacheOperation().getDSSMsgInSession(request)
+    val dwsHttpClient = HttpClient.getDSSClient(dssMsg.getDSSUrl)
+    val dssPrivilege = new DSSUserRolesImpl
+    dssPrivilege.setWorkspaceName(dssMsg.getWorkspaceName)
+    val userRoleInfoAction = new RoleInfoOfUserAction
+    userRoleInfoAction.setWorkspace(dssMsg.getWorkspaceName)
+    HttpClient.addCookies(dssMsg, userRoleInfoAction)
+    dwsHttpClient.execute(userRoleInfoAction) match {
+      case userRoleInfoResult: RoleInfoOfUserResult =>
+        dssPrivilege.setRoles(userRoleInfoResult.getRoles)
+        dssPrivilege.setUser(userRoleInfoResult.getUser)
+    }
+    dssPrivilege
+  }
+
+  override def getUsers(request: HttpServletRequest, role: String): util.List[String] = {
+    val dssMsg = ssoIntegrationStandard.getSSOPluginService
+      .createDssMsgCacheOperation().getDSSMsgInSession(request)
+    val dwsHttpClient = HttpClient.getDSSClient(dssMsg.getDSSUrl)
+    val userInfoOfRole = new UserInfoOfRoleAction
+    userInfoOfRole.setWorkspace(dssMsg.getWorkspaceName)
+    HttpClient.addCookies(dssMsg, userInfoOfRole)
+    dwsHttpClient.execute(userInfoOfRole) match {
+      case result: UserInfoOfRoleResult =>
+        result.getUsers
+    }
+  }
+}
+object OriginRolePlugin {
+  private val rolePlugin = new OriginRolePlugin
+  def getRolePlugin: RolePlugin = rolePlugin
+}

--- a/dss-standard/structure-standard/dss-role-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/plugin/role/impl/RoleInfoOfUserAction.scala
+++ b/dss-standard/structure-standard/dss-role-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/plugin/role/impl/RoleInfoOfUserAction.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.plugin.role.impl
+
+import com.webank.wedatasphere.linkis.httpclient.dws.request.DWSHttpAction
+import com.webank.wedatasphere.linkis.httpclient.request.POSTAction
+
+
+class RoleInfoOfUserAction extends POSTAction with DWSHttpAction {
+
+  override def suffixURLs: Array[String] = Array("dss", "getRolesOfWorkspaceUser")
+
+  override def getRequestPayload: String = ""
+
+  def setWorkspace(workspace: String): Unit = addRequestPayload("workspaceName", workspace)
+
+}

--- a/dss-standard/structure-standard/dss-role-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/plugin/role/impl/RoleInfoOfUserResult.scala
+++ b/dss-standard/structure-standard/dss-role-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/plugin/role/impl/RoleInfoOfUserResult.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.plugin.role.impl
+
+import com.webank.wedatasphere.linkis.httpclient.dws.annotation.DWSHttpMessageResult
+import com.webank.wedatasphere.linkis.httpclient.dws.response.DWSResult
+
+import scala.beans.BeanProperty
+
+
+@DWSHttpMessageResult("/api/rest_j/v\\d+/dss/getRolesOfWorkspaceUser")
+class RoleInfoOfUserResult extends DWSResult  {
+
+  @BeanProperty var user: String = _
+
+  @BeanProperty var roles: java.util.List[String] = _
+
+}

--- a/dss-standard/structure-standard/dss-role-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/plugin/role/impl/UserInfoOfRoleAction.scala
+++ b/dss-standard/structure-standard/dss-role-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/plugin/role/impl/UserInfoOfRoleAction.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.plugin.role.impl
+
+import com.webank.wedatasphere.linkis.httpclient.dws.request.DWSHttpAction
+import com.webank.wedatasphere.linkis.httpclient.request.POSTAction
+
+
+class UserInfoOfRoleAction extends POSTAction with DWSHttpAction {
+
+  override def suffixURLs: Array[String] = Array("dss", "getUsersOfWorkspaceRole")
+
+  def setWorkspace(workspace: String): Unit = addRequestPayload("workspaceName", workspace)
+
+  override def getRequestPayload: String = ""
+}

--- a/dss-standard/structure-standard/dss-role-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/plugin/role/impl/UserInfoOfRoleResult.scala
+++ b/dss-standard/structure-standard/dss-role-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/plugin/role/impl/UserInfoOfRoleResult.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.plugin.role.impl
+
+import com.webank.wedatasphere.linkis.httpclient.dws.annotation.DWSHttpMessageResult
+import com.webank.wedatasphere.linkis.httpclient.dws.response.DWSResult
+
+import scala.beans.BeanProperty
+
+
+@DWSHttpMessageResult("/api/rest_j/v\\d+/dss/getUsersOfWorkspaceRole")
+class UserInfoOfRoleResult extends DWSResult  {
+
+  @BeanProperty var users: java.util.List[String] = _
+
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/pom.xml
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>dss</artifactId>
+    <groupId>com.webank.wedatasphere.dss</groupId>
+    <version>1.0.0</version>
+    <relativePath>../../../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>dss-structure-integration-standard</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>com.webank.wedatasphere.linkis</groupId>
+      <artifactId>linkis-common</artifactId>
+      <version>${linkis.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.webank.wedatasphere.dss</groupId>
+      <artifactId>dss-sso-integration-standard</artifactId>
+      <version>${dss.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/AbstractStructureIntegrationStandard.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/AbstractStructureIntegrationStandard.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure;
+
+import com.webank.wedatasphere.dss.standard.app.sso.request.SSORequestService;
+import com.webank.wedatasphere.dss.standard.app.structure.project.ProjectService;
+import com.webank.wedatasphere.dss.standard.app.structure.role.RoleService;
+import com.webank.wedatasphere.dss.standard.app.structure.status.AppStatusService;
+import com.webank.wedatasphere.dss.standard.common.core.AbstractAppIntegrationStandard;
+import com.webank.wedatasphere.dss.standard.common.desc.AppInstance;
+
+import java.io.IOException;
+
+public abstract class AbstractStructureIntegrationStandard extends AbstractAppIntegrationStandard<StructureService, SSORequestService>
+    implements StructureIntegrationStandard {
+
+    protected abstract ProjectService createProjectService();
+
+    protected RoleService createRoleService() {
+        return null;
+    }
+
+    protected AppStatusService createAppStatusService() {
+        return null;
+    }
+
+    @Override
+    protected <T extends StructureService> void initService(T service) {
+        service.setAppStandard(this);
+    }
+
+    @Override
+    public void init()  {
+    }
+
+    @Override
+    public RoleService getRoleService(AppInstance appInstance) {
+        return getOrCreate(appInstance, this::createRoleService, RoleService.class);
+    }
+
+    @Override
+    public ProjectService getProjectService(AppInstance appInstance) {
+        return getOrCreate(appInstance, this::createProjectService, ProjectService.class);
+    }
+
+    @Override
+    public AppStatusService getAppStateService(AppInstance appInstance) {
+        return getOrCreate(appInstance, this::createAppStatusService, AppStatusService.class);
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/AbstractStructureService.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/AbstractStructureService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure;
+
+import com.webank.wedatasphere.dss.standard.app.sso.request.SSORequestService;
+import com.webank.wedatasphere.dss.standard.common.app.AppSingletonIntegrationServiceImpl;
+
+public class AbstractStructureService extends AppSingletonIntegrationServiceImpl<StructureOperation, SSORequestService> implements StructureService {
+
+    private StructureIntegrationStandard appStandard;
+
+    @Override
+    protected void initOperation(StructureOperation operation) {
+        operation.setStructureService(this);
+        operation.init();
+        super.initOperation(operation);
+    }
+
+    @Override
+    public void setAppStandard(StructureIntegrationStandard appStandard) {
+        this.appStandard = appStandard;
+    }
+
+    @Override
+    public StructureIntegrationStandard getAppStandard() {
+        return appStandard;
+    }
+
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/StructureIntegrationStandard.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/StructureIntegrationStandard.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure;
+
+import com.webank.wedatasphere.dss.standard.app.sso.request.SSORequestService;
+import com.webank.wedatasphere.dss.standard.app.structure.project.ProjectService;
+import com.webank.wedatasphere.dss.standard.app.structure.role.RoleService;
+import com.webank.wedatasphere.dss.standard.app.structure.status.AppStatusService;
+import com.webank.wedatasphere.dss.standard.common.core.AppIntegrationStandard;
+import com.webank.wedatasphere.dss.standard.common.core.AppStandard;
+import com.webank.wedatasphere.dss.standard.common.desc.AppInstance;
+
+
+public interface StructureIntegrationStandard extends AppIntegrationStandard<SSORequestService> {
+
+    /**
+     * 统一角色规范，用于打通DSS与各集成接入系统的角色体系
+     * @return
+     */
+    RoleService getRoleService(AppInstance appInstance);
+
+    /**
+     * 统一工程规范，用于打通DSS与各集成接入系统的工程体系
+     * @return
+     */
+    ProjectService getProjectService(AppInstance appInstance);
+
+    AppStatusService getAppStateService(AppInstance appInstance);
+
+    @Override
+    default String getStandardName() {
+        return "structureIntegrationStandard";
+    }
+
+    @Override
+    default int getGrade() {
+        return 2;
+    }
+
+    @Override
+    default boolean isNecessary() {
+        return false;
+    }
+
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/StructureOperation.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/StructureOperation.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure;
+
+
+import com.webank.wedatasphere.dss.standard.common.service.Operation;
+
+
+public interface StructureOperation extends Operation {
+
+    void init();
+
+    void setStructureService(StructureService service);
+
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/StructureService.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/StructureService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure;
+
+
+import com.webank.wedatasphere.dss.standard.app.sso.request.SSORequestService;
+import com.webank.wedatasphere.dss.standard.common.app.AppIntegrationService;
+
+
+public interface StructureService extends AppIntegrationService<SSORequestService> {
+
+    void setAppStandard(StructureIntegrationStandard appStandard);
+
+    StructureIntegrationStandard getAppStandard();
+
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/ProjectCreationOperation.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/ProjectCreationOperation.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project;
+
+import com.webank.wedatasphere.dss.standard.app.structure.StructureOperation;
+import com.webank.wedatasphere.dss.standard.common.exception.operation.ExternalOperationFailedException;
+
+
+public interface ProjectCreationOperation extends StructureOperation {
+
+    ProjectResponseRef createProject(ProjectRequestRef projectRef) throws ExternalOperationFailedException;
+
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/ProjectDeletionOperation.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/ProjectDeletionOperation.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project;
+
+import com.webank.wedatasphere.dss.standard.app.structure.StructureOperation;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+import com.webank.wedatasphere.dss.standard.common.exception.operation.ExternalOperationFailedException;
+
+
+public interface ProjectDeletionOperation extends StructureOperation {
+
+    ResponseRef deleteProject(ProjectRequestRef projectRef) throws ExternalOperationFailedException;
+
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/ProjectRequestRef.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/ProjectRequestRef.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project;
+
+import com.webank.wedatasphere.dss.standard.app.sso.Workspace;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.RequestRef;
+
+
+public interface ProjectRequestRef extends RequestRef {
+
+    String getWorkspaceName();
+
+    Long getId();
+
+    void setId(Long id);
+
+    @Override
+    String getName();
+
+    void setName(String name);
+
+    String getDescription();
+
+    void setDescription(String description);
+
+    String getCreateBy();
+
+    void setCreateBy(String createBy);
+
+    String getUpdateBy();
+
+    void setUpdateBy(String updateBy);
+
+    default void setWorkspace(Workspace workspace){
+
+    }
+
+    default Workspace getWorkspace(){
+        return null;
+    }
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/ProjectRequestRefImpl.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/ProjectRequestRefImpl.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project;
+
+import com.webank.wedatasphere.dss.standard.app.sso.Workspace;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.AbstractRequestRef;
+
+
+public class ProjectRequestRefImpl extends AbstractRequestRef implements ProjectRequestRef {
+
+
+
+    private String workspaceName;
+
+    private String createBy;
+
+    private String updateBy;
+
+    private Long id;
+
+    private String name;
+
+    private String description;
+
+    private Workspace workspace;
+
+    @Override
+    public String getWorkspaceName() {
+        return workspaceName;
+    }
+
+    public void setWorkspaceName(String workspaceName) {
+        this.workspaceName = workspaceName;
+    }
+
+    @Override
+    public Long getId() {
+        return this.id;
+    }
+
+    @Override
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public String getCreateBy() {
+        return this.createBy;
+    }
+
+    @Override
+    public void setCreateBy(String createBy) {
+        this.createBy = createBy;
+    }
+
+    @Override
+    public String getUpdateBy() {
+        return updateBy;
+    }
+
+    @Override
+    public void setUpdateBy(String updateBy) {
+        this.updateBy = updateBy;
+    }
+
+
+    @Override
+    public Workspace getWorkspace() {
+        return workspace;
+    }
+
+    @Override
+    public void setWorkspace(Workspace workspace) {
+        this.workspace = workspace;
+    }
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/ProjectResponseRef.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/ProjectResponseRef.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project;
+
+import com.webank.wedatasphere.dss.standard.common.desc.AppInstance;
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+
+import java.util.List;
+import java.util.Map;
+
+
+public interface ProjectResponseRef extends ResponseRef {
+
+    Long getProjectRefId();
+
+    Map<AppInstance, Long> getProjectRefIds();
+
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/ProjectService.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/ProjectService.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project;
+
+import com.webank.wedatasphere.dss.standard.app.structure.AbstractStructureService;
+
+
+public abstract class ProjectService extends AbstractStructureService {
+
+    /**
+     * 是否支持DSS与各集成接入系统的协同开发能力
+     * @return 默认为false
+     */
+    public boolean isCooperationSupported() {
+        return false;
+    }
+
+    public boolean isProjectNameUnique() {
+        return true;
+    }
+
+   public ProjectCreationOperation getProjectCreationOperation() {
+       return getOrCreate(this::createProjectCreationOperation, ProjectCreationOperation.class);
+   }
+
+   protected abstract ProjectCreationOperation createProjectCreationOperation();
+
+   public ProjectUpdateOperation getProjectUpdateOperation() {
+       return getOrCreate(this::createProjectUpdateOperation, ProjectUpdateOperation.class);
+   }
+
+   protected abstract ProjectUpdateOperation createProjectUpdateOperation();
+
+   public ProjectDeletionOperation getProjectDeletionOperation() {
+       return getOrCreate(this::createProjectDeletionOperation, ProjectDeletionOperation.class);
+   }
+
+   protected abstract ProjectDeletionOperation createProjectDeletionOperation();
+
+   public ProjectUrlOperation getProjectUrlOperation() {
+       return getOrCreate(this::createProjectUrlOperation, ProjectUrlOperation.class);
+   }
+
+   protected abstract ProjectUrlOperation createProjectUrlOperation();
+
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/ProjectUpdateOperation.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/ProjectUpdateOperation.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project;
+
+import com.webank.wedatasphere.dss.standard.app.structure.StructureOperation;
+import com.webank.wedatasphere.dss.standard.common.exception.operation.ExternalOperationFailedException;
+
+
+public interface ProjectUpdateOperation extends StructureOperation {
+
+    ProjectResponseRef updateProject(ProjectRequestRef projectRef) throws ExternalOperationFailedException;
+
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/ProjectUrlOperation.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/ProjectUrlOperation.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project;
+
+import com.webank.wedatasphere.dss.standard.app.structure.StructureOperation;
+import com.webank.wedatasphere.dss.standard.common.exception.operation.ExternalOperationFailedException;
+
+
+public interface ProjectUrlOperation extends StructureOperation {
+
+    String getProjectUrl(ProjectRequestRef project)  throws ExternalOperationFailedException;
+
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/role/Role.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/role/Role.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.role;
+
+import java.util.Date;
+
+
+public interface Role {
+
+    String getName();
+
+    String getShowName();
+
+    Date getCreateTime();
+
+    String getCreator();
+
+    String getDescription();
+
+    String getUpdator();
+
+    String getLastUpdateTime();
+
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/role/RoleCreationOperation.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/role/RoleCreationOperation.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.role;
+
+import com.webank.wedatasphere.dss.standard.app.structure.StructureOperation;
+
+import java.util.Map;
+
+
+public interface RoleCreationOperation extends StructureOperation {
+
+    RoleResponseRef createRole(String workspaceName, Role role);
+
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/role/RoleDeletionOperation.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/role/RoleDeletionOperation.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.role;
+
+import com.webank.wedatasphere.dss.standard.app.structure.StructureOperation;
+
+import java.util.Map;
+
+
+public interface RoleDeletionOperation extends StructureOperation {
+
+    RoleResponseRef deleteRole(String workspaceName, Role role);
+
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/role/RoleResponseRef.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/role/RoleResponseRef.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.role;
+
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+
+public interface RoleResponseRef extends ResponseRef {
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/role/RoleService.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/role/RoleService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.role;
+
+import com.webank.wedatasphere.dss.standard.app.structure.StructureService;
+
+
+public interface RoleService extends StructureService {
+
+    RoleCreationOperation createRoleCreationOperation();
+
+    RoleUpdateOperation createRoleUpdateOperation();
+
+    RoleDeletionOperation createRoleDeletionOperation();
+
+    RoleUrlOperation createRoleUrlOperation();
+
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/role/RoleUpdateOperation.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/role/RoleUpdateOperation.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.role;
+
+import com.webank.wedatasphere.dss.standard.app.structure.StructureOperation;
+
+import java.util.Map;
+
+
+public interface RoleUpdateOperation extends StructureOperation {
+
+    RoleResponseRef updateRole(String workspaceName, Role fromRole, Role toRole);
+
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/role/RoleUrlOperation.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/role/RoleUrlOperation.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.role;
+
+import com.webank.wedatasphere.dss.standard.app.structure.StructureOperation;
+
+
+public interface RoleUrlOperation extends StructureOperation {
+
+    RoleResponseRef getRoleUrl(String workspaceName, Role role);
+
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/status/AppStatus.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/status/AppStatus.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.status;
+
+import com.webank.wedatasphere.dss.standard.common.desc.AppInstance;
+
+import java.util.List;
+
+
+public interface AppStatus {
+
+    boolean isHealthy();
+
+    List<AppInstance> getUnreachableAppInstance();
+
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/status/AppStatusOperation.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/status/AppStatusOperation.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.status;
+
+import com.webank.wedatasphere.dss.standard.app.structure.StructureOperation;
+
+
+public interface AppStatusOperation extends StructureOperation {
+
+    AppStatusResponseRef heartbeat();
+
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/status/AppStatusResponseRef.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/status/AppStatusResponseRef.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.status;
+
+import com.webank.wedatasphere.dss.standard.common.entity.ref.ResponseRef;
+
+public interface AppStatusResponseRef extends ResponseRef {
+
+    AppStatus getAppStatus();
+
+}

--- a/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/status/AppStatusService.java
+++ b/dss-standard/structure-standard/dss-structure-integration-standard/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/status/AppStatusService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.status;
+
+import com.webank.wedatasphere.dss.standard.app.structure.StructureService;
+
+
+public interface AppStatusService extends StructureService {
+
+    AppStatusOperation createAppStatusOperation();
+
+}

--- a/dss-standard/structure-standard/spring-origin-dss-project-plugin/pom.xml
+++ b/dss-standard/structure-standard/spring-origin-dss-project-plugin/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 WeBank
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>dss</artifactId>
+    <groupId>com.webank.wedatasphere.dss</groupId>
+    <version>1.0.0</version>
+    <relativePath>../../../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>spring-origin-dss-project-plugin</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.webank.wedatasphere.dss</groupId>
+      <artifactId>dss-project-plugin</artifactId>
+      <version>${dss.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>${spring.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <version>${spring.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <version>${spring.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/dss-standard/structure-standard/spring-origin-dss-project-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/filter/ProjectCooperationSpringFilter.java
+++ b/dss-standard/structure-standard/spring-origin-dss-project-plugin/src/main/java/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/filter/ProjectCooperationSpringFilter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project.plugin.filter;
+
+import com.webank.wedatasphere.dss.standard.app.sso.plugin.filter.UserInterceptor;
+import com.webank.wedatasphere.dss.standard.app.structure.project.plugin.ProjectCooperationPlugin;
+import com.webank.wedatasphere.dss.standard.app.structure.project.plugin.origin.OriginProjectCooperationPlugin;
+import javax.servlet.FilterConfig;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
+
+
+@Component
+public class ProjectCooperationSpringFilter extends ProjectCooperationFilter {
+
+    @Override
+    public ProjectAuthInterceptor getProjectAuthInterceptor(FilterConfig filterConfig) {
+        WebApplicationContext webApplicationContext =
+            WebApplicationContextUtils.getRequiredWebApplicationContext(filterConfig.getServletContext());
+        return webApplicationContext.getBean(ProjectAuthInterceptor.class);
+    }
+
+    @Override
+    public UserInterceptor getUserAuthInterceptor(FilterConfig filterConfig) {
+        WebApplicationContext webApplicationContext =
+            WebApplicationContextUtils.getRequiredWebApplicationContext(filterConfig.getServletContext());
+        return webApplicationContext.getBean(UserInterceptor.class);
+    }
+
+    @Override
+    public ProjectCooperationPlugin getProjectCooperationPlugin(FilterConfig filterConfig) {
+        return OriginProjectCooperationPlugin.getProjectCooperatePlugin();
+    }
+}

--- a/dss-standard/structure-standard/spring-origin-dss-project-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/origin/OriginProjectCooperationPlugin.scala
+++ b/dss-standard/structure-standard/spring-origin-dss-project-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/origin/OriginProjectCooperationPlugin.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project.plugin.origin
+
+import com.webank.wedatasphere.dss.standard.app.sso.SSOIntegrationStandard
+import com.webank.wedatasphere.dss.standard.app.sso.builder.DssMsgBuilderOperation.DSSMsg
+import com.webank.wedatasphere.dss.standard.app.sso.origin.OriginSSOIntegrationStandardFactory
+import com.webank.wedatasphere.dss.standard.app.sso.origin.client.HttpClient
+import com.webank.wedatasphere.dss.standard.app.structure.project.plugin.{ProjectAuth, ProjectCooperationPlugin}
+import com.webank.wedatasphere.linkis.httpclient.request.HttpAction
+import javax.servlet.http.HttpServletRequest
+
+
+class OriginProjectCooperationPlugin private() extends ProjectCooperationPlugin {
+ private val ssoIntegrationStandard:SSOIntegrationStandard =new OriginSSOIntegrationStandardFactory().getSSOIntegrationStandard
+
+  private def getProjectAuth(action: HttpAction, dssMsg: DSSMsg): ProjectAuthImpl = {
+    val dwsHttpClient = HttpClient.getDSSClient(dssMsg.getDSSUrl)
+    val projectAuth = new ProjectAuthImpl
+    projectAuth.setWorkspaceName(dssMsg.getWorkspaceName)
+    HttpClient.addCookies(dssMsg, action)
+    dwsHttpClient.execute(action) match {
+      case projectAuthResult: ProjectAuthResult =>
+        projectAuth.setProjectId(projectAuthResult.getProjectId)
+        projectAuth.setProjectName(projectAuthResult.getProjectName)
+        projectAuth.setEditUsers(projectAuthResult.getEditUsers)
+        projectAuth.setAccessUsers(projectAuthResult.getAccessUsers)
+        projectAuth.setDeleteUsers(projectAuthResult.getDeleteUsers)
+    }
+    projectAuth
+  }
+
+  override def getProjectAuth(request: HttpServletRequest, projectId: String): ProjectAuth = {
+    val dssMsg = ssoIntegrationStandard.getSSOPluginService
+      .createDssMsgCacheOperation().getDSSMsgInSession(request)
+    val projectAuthAction = new ProjectAuthByIdAction
+    projectAuthAction.setWorkspace(dssMsg.getWorkspaceName)
+    projectAuthAction.setProjectId(projectId)
+    projectAuthAction.setComponentName(dssMsg.getAppName)
+    val projectAuth = getProjectAuth(projectAuthAction, dssMsg)
+    projectAuth.setProjectId(projectId)
+    projectAuth
+  }
+
+  override def getProjectAuthByName(request: HttpServletRequest, projectName: String): ProjectAuth = {
+
+    val dssMsg = ssoIntegrationStandard.getSSOPluginService
+      .createDssMsgCacheOperation().getDSSMsgInSession(request)
+    val projectAuthAction = new ProjectAuthByNameAction
+    projectAuthAction.setProjectName(projectName)
+    projectAuthAction.setWorkspace(dssMsg.getWorkspaceName)
+    val projectAuth = getProjectAuth(projectAuthAction, dssMsg)
+    projectAuth.setProjectName(projectName)
+    projectAuth
+  }
+}
+object OriginProjectCooperationPlugin {
+  private val projectCooperatePlugin = new OriginProjectCooperationPlugin
+  def getProjectCooperatePlugin: ProjectCooperationPlugin = projectCooperatePlugin
+}

--- a/dss-standard/structure-standard/spring-origin-dss-project-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/origin/OriginProjectPlugin.scala
+++ b/dss-standard/structure-standard/spring-origin-dss-project-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/origin/OriginProjectPlugin.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project.plugin.origin
+
+import java.util
+
+import com.webank.wedatasphere.dss.standard.app.sso.SSOIntegrationStandard
+import com.webank.wedatasphere.dss.standard.app.sso.origin.OriginSSOIntegrationStandardFactory
+import com.webank.wedatasphere.dss.standard.app.sso.origin.client.HttpClient
+import com.webank.wedatasphere.dss.standard.app.structure.project.plugin.ProjectPlugin
+import javax.servlet.http.HttpServletRequest
+
+
+class OriginProjectPlugin private() extends ProjectPlugin {
+
+  override def getProjects(request: HttpServletRequest): util.List[String] = {
+    val ssoIntegrationStandard:SSOIntegrationStandard =new OriginSSOIntegrationStandardFactory().getSSOIntegrationStandard
+    val dssMsg =ssoIntegrationStandard.getSSOPluginService.createDssMsgCacheOperation().getDSSMsgInSession(request)
+    val dwsHttpClient = HttpClient.getDSSClient(dssMsg.getDSSUrl)
+    val projectListAction = new ProjectListByWorkspaceAction
+    projectListAction.setWorkspace(dssMsg.getWorkspaceName)
+    HttpClient.addCookies(dssMsg, projectListAction)
+    dwsHttpClient.execute(projectListAction) match {
+      case projectListResult: ProjectListByWorkspaceResult =>
+        projectListResult.getProjectIds
+    }
+  }
+
+}
+object OriginProjectPlugin {
+  private val projectPlugin = new OriginProjectPlugin
+  def getProjectPlugin: ProjectPlugin = projectPlugin
+}

--- a/dss-standard/structure-standard/spring-origin-dss-project-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/origin/ProjectAuthByIdAction.scala
+++ b/dss-standard/structure-standard/spring-origin-dss-project-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/origin/ProjectAuthByIdAction.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project.plugin.origin
+
+import com.webank.wedatasphere.linkis.httpclient.dws.request.DWSHttpAction
+import com.webank.wedatasphere.linkis.httpclient.request.POSTAction
+
+
+class ProjectAuthByIdAction extends POSTAction with DWSHttpAction {
+
+  override def suffixURLs: Array[String] = Array("dss", "getProjectAuthOfWorkspace")
+
+  def setWorkspace(workspaceName: String): Unit = addRequestPayload("workspaceName", workspaceName)
+
+  def setProjectId(projectId: String): Unit = addRequestPayload("projectId", projectId)
+
+  def setComponentName(componentName: String): Unit = addRequestPayload("componentName", componentName)
+
+  override def getRequestPayload: String = ""
+}

--- a/dss-standard/structure-standard/spring-origin-dss-project-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/origin/ProjectAuthByNameAction.scala
+++ b/dss-standard/structure-standard/spring-origin-dss-project-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/origin/ProjectAuthByNameAction.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project.plugin.origin
+
+import com.webank.wedatasphere.linkis.httpclient.dws.request.DWSHttpAction
+import com.webank.wedatasphere.linkis.httpclient.request.POSTAction
+
+
+class ProjectAuthByNameAction extends POSTAction with DWSHttpAction {
+
+  override def suffixURLs: Array[String] = Array("dss", "getProjectAuthOfWorkspace")
+
+  def setWorkspace(workspaceName: String): Unit = addRequestPayload("workspaceName", workspaceName)
+
+  def setProjectName(projectName: String): Unit = addRequestPayload("projectName", projectName)
+
+  override def getRequestPayload: String = ""
+}

--- a/dss-standard/structure-standard/spring-origin-dss-project-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/origin/ProjectAuthResult.scala
+++ b/dss-standard/structure-standard/spring-origin-dss-project-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/origin/ProjectAuthResult.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project.plugin.origin
+
+import scala.beans.BeanProperty
+import java.util
+
+import com.webank.wedatasphere.linkis.httpclient.dws.annotation.DWSHttpMessageResult
+import com.webank.wedatasphere.linkis.httpclient.dws.response.DWSResult
+
+
+@DWSHttpMessageResult("/api/rest_j/v\\d+/dss/getProjectAuthOfWorkspace")
+class ProjectAuthResult extends DWSResult {
+
+  @BeanProperty
+  var projectName: String = _
+
+  @BeanProperty
+  var projectId: String = _
+
+  @BeanProperty
+  var workspaceName: String = _
+
+  @BeanProperty
+  var editUsers: util.List[String] = _
+
+  @BeanProperty
+  var accessUsers: util.List[String] = _
+
+  @BeanProperty
+  var deleteUsers: util.List[String] = _
+
+}

--- a/dss-standard/structure-standard/spring-origin-dss-project-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/origin/ProjectListByWorkspaceAction.scala
+++ b/dss-standard/structure-standard/spring-origin-dss-project-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/origin/ProjectListByWorkspaceAction.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project.plugin.origin
+
+import com.webank.wedatasphere.linkis.httpclient.dws.request.DWSHttpAction
+import com.webank.wedatasphere.linkis.httpclient.request.POSTAction
+
+
+class ProjectListByWorkspaceAction extends POSTAction with DWSHttpAction {
+
+  override def suffixURLs: Array[String] = Array("dss", "getProjectListOfWorkspace")
+
+  def setWorkspace(workspaceName: String): Unit = addRequestPayload("workspaceName", workspaceName)
+
+  override def getRequestPayload: String = ""
+}

--- a/dss-standard/structure-standard/spring-origin-dss-project-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/origin/ProjectListByWorkspaceResult.scala
+++ b/dss-standard/structure-standard/spring-origin-dss-project-plugin/src/main/scala/com/webank/wedatasphere/dss/standard/app/structure/project/plugin/origin/ProjectListByWorkspaceResult.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 WeBank
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.webank.wedatasphere.dss.standard.app.structure.project.plugin.origin
+
+import java.util
+
+import com.webank.wedatasphere.linkis.httpclient.dws.annotation.DWSHttpMessageResult
+import com.webank.wedatasphere.linkis.httpclient.dws.response.DWSResult
+
+import scala.beans.BeanProperty
+
+
+@DWSHttpMessageResult("/api/rest_j/v\\d+/dss/getProjectListOfWorkspace")
+class ProjectListByWorkspaceResult extends DWSResult {
+
+  @BeanProperty
+  var projectIds: util.List[String] = _
+
+}


### PR DESCRIPTION
### What is the purpose of the change
Add dss-standard module, which is three kind of basic request protocol to integrate with upper-layer application systems.

### Brief change log
- Defines the third-level development standard of AppConn, which used to integrate with third-party data application tools for workflow node management.
- Provide DSS standard commons module, adapt to the new architecture of DSS1.0.
- Defines the second-level development standard of AppConn, which used to integrate with third-party data application tools for project and role management.
- Defines the first-level development standard of AppConn, which used to integrate with third-party data application tools for SSO login.

close #373 
close #372 
close #371 
close #370 