### PR TITLE
Dev DSS 1.0.0 BUG 解决schedules kill任务后EventcheckReceiver依旧在后台运行

### DIFF
--- a/dss-appconn/appconns/dss-eventchecker-appconn/src/main/scala/com/webank/wedatasphere/dss/appconn/eventchecker/execution/EventCheckerRefExecutionOperation.scala
+++ b/dss-appconn/appconns/dss-eventchecker-appconn/src/main/scala/com/webank/wedatasphere/dss/appconn/eventchecker/execution/EventCheckerRefExecutionOperation.scala
@@ -126,6 +126,7 @@ class EventCheckerRefExecutionOperation  extends LongTermRefExecutionOperation w
             false
           })
           if(killTag)
+            killTag = false
             return RefExecutionState.Killed
         }
         action.state


### PR DESCRIPTION
问题见图:
dss全局历史显示被kill,后台任然在运行
![image](https://user-images.githubusercontent.com/28647031/137848818-de0da706-cf0b-4761-8855-b6e929e19b93.png)
