### PR TITLE
Could com.webank.wedatasphere.dss:dss-appconn-loader:1.0.1 drop off redundant dependencies?

### DIFF
--- a/dss-appconn/dss-appconn-loader/pom.xml
+++ b/dss-appconn/dss-appconn-loader/pom.xml
@@ -34,6 +34,20 @@
             <groupId>com.webank.wedatasphere.dss</groupId>
             <artifactId>dss-appconn-core</artifactId>
             <version>${dss.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.webank.wedatasphere.dss</groupId>
+                    <artifactId>dss-development-process-standard</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.json4s</groupId>
+                    <artifactId>json4s-jackson_2.11</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -48,6 +62,12 @@
             <artifactId>dss-common</artifactId>
             <version>${dss.version}</version>
             <scope>provided</scope>
+        </dependency>
+      
+        <dependency>
+            <groupId>org.json4s</groupId>
+            <artifactId>json4s-core_2.11</artifactId>
+            <version>3.5.3</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/78527112/167550000-c7eaf9e9-5cab-4ec6-b96d-26975f59c09c.png)
Hi! I found the pom file of project **_com.webank.wedatasphere.dss:dss-appconn-loader:1.0.1_** introduced **_24_** dependencies. However, among them, **_4_** libraries (**_16%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
org.scala-lang.modules:scala-xml_2.11:jar:1.0.5:compile
org.json4s:json4s-jackson_2.11:jar:3.5.3:compile
javax.servlet:javax.servlet-api:jar:3.1.0:compile
com.webank.wedatasphere.dss:dss-development-process-standard:jar:1.0.1:compile
## Outdated dependencies
javax.servlet:javax.servlet-api:3.1.0 (**_3747_** days without maintenance)
org.scala-lang.modules:scala-xml_2.11:1.0.5 (**_2927_** days without maintenance)

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, As such, I suggest a refactoring operation for **_com.webank.wedatasphere.dss:dss-appconn-loader:1.0.1_**’s pom file.

As shown in the figure, it is noteworthy that, libraries **_org.json4s:json4s-core_2.11::3.5.3:compile_** are invoked by the projects. When we remove the redundant dependency **_org.json4s:json4s-jackson_2.11::3.5.3:compile_**, the above **_org.json4s:json4s-core_2.11::3.5.3:compile_** should be declared as direct dependencies. The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_com.webank.wedatasphere.dss:dss-appconn-loader:1.0.1_**’s maven tests.

Best regards