### PR TITLE
fix:type conversion exception

### DIFF
--- a/plugins/dolphinscheduler/dss-dolphinscheduler-token/src/main/java/com/webank/wedatasphere/dss/dolphinscheduler/token/restful/DolphinSchedulerTokenRestfulApi.java
+++ b/plugins/dolphinscheduler/dss-dolphinscheduler-token/src/main/java/com/webank/wedatasphere/dss/dolphinscheduler/token/restful/DolphinSchedulerTokenRestfulApi.java
@@ -35,6 +35,6 @@ public class DolphinSchedulerTokenRestfulApi {
                 .getOptionalService(appInstance).getOptionalOperation("getToken");
         ResponseRef responseRef = optionalOperation.apply(new StructureRequestRefImpl().setUserName(userName));
         return Message.ok().data("token", responseRef.getValue("token"))
-                .data("expire_time", Long.valueOf((String)responseRef.getValue("expireTime")));
+                .data("expire_time", responseRef.getValue("expireTime"));
     }
 }


### PR DESCRIPTION
### What is the purpose of the change
https://github.com/WeBankFinTech/DataSphereStudio/issues/899

### Brief change log
- com.webank.wedatasphere.dss.dolphinscheduler.token.restful.DolphinSchedulerTokenRestfulApi


### Verifying this change  
- After integrating the dolphin scheduler component,request /dss/framework/project/ds/token api.
- See com webank. wedatasphere. dss. appconn. dolphinscheduler. operation. In the apply method of dolphin scheduler token getoperation, the expireTime field here returns the long type.

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The Core framework, i.e., AppConn, Orchestrator, ApiService.: (no)

### Documentation
- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)