### PR TITLE
Add the engine's version in the properties of ds-client 

### DIFF
--- a/plugins/dolphinscheduler/dss-dolphinscheduler-client/src/main/resources/linkis.properties
+++ b/plugins/dolphinscheduler/dss-dolphinscheduler-client/src/main/resources/linkis.properties
@@ -1,2 +1,5 @@
 wds.linkis.gateway.url=
 wds.linkis.flow.job.creator.v1=DolphinScheduler
+
+#wds.linkis.spark.engine.version=3.1.
+#wds.linkis.hive.engine.version=2.3.3

--- a/plugins/dolphinscheduler/dss-dolphinscheduler-client/src/main/resources/linkis.properties
+++ b/plugins/dolphinscheduler/dss-dolphinscheduler-client/src/main/resources/linkis.properties
@@ -1,5 +1,5 @@
 wds.linkis.gateway.url=
 wds.linkis.flow.job.creator.v1=DolphinScheduler
 
-#wds.linkis.spark.engine.version=3.1.
+#wds.linkis.spark.engine.version=2.4.3
 #wds.linkis.hive.engine.version=2.3.3


### PR DESCRIPTION
### What is the purpose of the change
Let users how to modify the engine version in linkis.properties

### Brief change log
(for example:)
- Add the engine version(Spark,Hive) in the ;DataSphereStudio/plugins/dolphinscheduler/dss-dolphinscheduler-client/src/main/resources/linkis.properties

### Verifying this change
This change added tests and can be verified as follows:  
- Modify spark version from 2.4.3 to 3.1.2
- And the sql"show databases"can run in the env (spark.version=3.1.2,linkis=1.1.1,DSS=1.1.0) 

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no )
- The Core framework, i.e., AppConn, Orchestrator, ApiService.: (no)
