### PR TITLE
修复发送邮件截图在正文中不显示的问题

### DIFF
--- a/dss-appconn/appconns/dss-sendemail-appconn/sendemail-appconn-core/src/main/java/com/webank/wedatasphere/dss/appconn/sendemail/email/sender/SpringJavaEmailSender.java
+++ b/dss-appconn/appconns/dss-sendemail-appconn/sendemail-appconn-core/src/main/java/com/webank/wedatasphere/dss/appconn/sendemail/email/sender/SpringJavaEmailSender.java
@@ -98,10 +98,12 @@ public class SpringJavaEmailSender extends AbstractEmailSender {
             if (StringUtils.isNotBlank(email.getBcc())) {
                 messageHelper.setBcc(email.getBcc());
             }
+            messageHelper.setText(email.getContent(), true);
             for (Attachment attachment : email.getAttachments()) {
+                messageHelper.addInline(attachment.getName(), new ByteArrayDataSource(Base64.getMimeDecoder().decode(attachment.getBase64Str()), attachment.getMediaType()));
                 messageHelper.addAttachment(attachment.getName(), new ByteArrayDataSource(Base64.getMimeDecoder().decode(attachment.getBase64Str()), attachment.getMediaType()));
             }
-            messageHelper.setText(email.getContent(), true);
+
         } catch (Exception e) {
             logger.error("Send mail failed", e);
         }


### PR DESCRIPTION
### What is the purpose of the change
修复dss工作流程节点发送邮件，邮件正文中不显示图片的问题

### Brief change log
Spring官方说明中要求MimeMessageHelper添加文本和资源的顺序需要先确保文本再添加资源，所以做了以下两步
1.将messageHelper.setText(email.getContent(), true)放到前面
2.增加messageHelper.addAttachment(attachment.getName(), new ByteArrayDataSource(Base64.getMimeDecoder().decode(attachment.getBase64Str()), attachment.getMediaType()))用于添加资源

### Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- Anything that affects deployment: (no)
- The Core framework, i.e., AppConn, Orchestrator, ApiService.: (yes)

### Documentation
- Does this pull request introduce a new feature? (no)