### PR TITLE
Update pom.xml

### DIFF
--- a/dss-orchestrator/orchestrators/dss-workflow/dss-flow-execution-server/pom.xml
+++ b/dss-orchestrator/orchestrators/dss-workflow/dss-flow-execution-server/pom.xml
@@ -28,12 +28,6 @@
     <artifactId>dss-flow-execution-server</artifactId>
 
     <dependencies>
-
-        <dependency>
-            <groupId>org.apache.linkis</groupId>
-            <artifactId>linkis-jobhistory</artifactId>
-            <version>${linkis.version}</version>
-        </dependency>
         <dependency>
             <groupId>org.apache.linkis</groupId>
             <artifactId>linkis-entrance</artifactId>


### PR DESCRIPTION
Workflow Execution Module removes the useless dependency of linkis

### What is the purpose of the change
To fix the workflow execution module reference linkis library tables problem, the workflow execution module removes the redundant dependency of linkis

### Brief change log

- removes the useless dependency jobhistory of linkis;


### Verifying this change
- Recompile without error，And no place for use was found

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (yes )
- Anything that affects deployment: ( no )
- The Core framework, i.e., AppConn, Orchestrator, ApiService.: (no)

### Documentation
- Does this pull request introduce a new feature? ( no)
