### PR TITLE
Update init.sql

### DIFF
--- a/dss-appconn/appconns/dss-dolphinscheduler-appconn/src/main/resources/init.sql
+++ b/dss-appconn/appconns/dss-dolphinscheduler-appconn/src/main/resources/init.sql
@@ -20,6 +20,7 @@ VALUES(@dolphinscheduler_appconnId, @dolphinscheduler_menuId,'dolphinscheduler',
 
 delete from dss_workspace_dictionary where dic_key = "pom_work_flow_ds";
 delete from dss_workspace_dictionary where dic_key = "pom_work_flow_ds_DAG";
+delete from dss_workspace_dictionary where dic_key = "pdp_scheduler_center";
 insert  into `dss_workspace_dictionary`(`workspace_id`,`parent_key`,`dic_name`,`dic_name_en`,`dic_key`,`dic_value`,`dic_value_en`,`title`,`title_en`,`url`,`url_type`,`icon`,`order_num`,`remark`,`create_user`,`create_time`,`update_user`,`update_time`) values (0,'p_orchestrator_mode','DS工作流','Workflow_DS','pom_work_flow_ds','radio',NULL,NULL,NULL,NULL,0,'gongzuoliu-icon',1,'工程编排模式-DS工作流','SYSTEM','2022-03-21 14:25:35',NULL,'2022-03-21 14:25:35');
 insert  into `dss_workspace_dictionary`(`workspace_id`,`parent_key`,`dic_name`,`dic_name_en`,`dic_key`,`dic_value`,`dic_value_en`,`title`,`title_en`,`url`,`url_type`,`icon`,`order_num`,`remark`,`create_user`,`create_time`,`update_user`,`update_time`) values (0,'pom_work_flow_ds','DAG','DAG','pom_work_flow_ds_DAG',NULL,NULL,NULL,NULL,NULL,0,NULL,1,'工程编排模式-DS工作流-DAG','SYSTEM','2022-03-21 14:25:35',NULL,'2022-03-21 14:25:35');
 


### PR DESCRIPTION
when install dolphinSchedulerAppConn with cmd: "sh install-appconn.sh" ,got error like: "duplicate entry '0-pdp_scheduler_center' for key 'idx_unique_workspace_id'", delete the duplicate key before execute the insert command can avoid this.