### PR TITLE
fix: 1.3.2 fix saving script when using hdfs

### DIFF
--- a/web/packages/scriptis/module/workbench/script/editor.vue
+++ b/web/packages/scriptis/module/workbench/script/editor.vue
@@ -38,7 +38,7 @@
             <span class="navbar-item-name">{{ $t('message.scripts.editorDetail.navBar.stop') }}</span>
           </div>
           <div
-            v-if="!script.readOnly && !isHdfs"
+            v-if="!script.readOnly"
             class="workbench-body-navbar-item"
             title="Ctrl+S"
             @click="save">
@@ -46,7 +46,7 @@
             <span class="navbar-item-name">{{ $t('message.scripts.editorDetail.navBar.save') }}</span>
           </div>
           <div
-            v-if="!script.readOnly && !isHdfs && isSupport"
+            v-if="!script.readOnly && isSupport"
             class="workbench-body-navbar-item"
             @click="config">
             <Icon type="ios-build" />

--- a/web/packages/scriptis/module/workbench/script/script.vue
+++ b/web/packages/scriptis/module/workbench/script/script.vue
@@ -1076,9 +1076,9 @@ export default {
           params: this.convertSettingParams(this.script.params),
         };
           // this.work.code = this.script.data;
-        const isHdfs = this.work.filepath.indexOf('hdfs') === 0;
+        // const isHdfs = this.work.filepath.indexOf('hdfs') === 0;
         if (this.script.data) {
-          if (this.work.unsave && !isHdfs) {
+          if (this.work.unsave) {
             if (this.work.filepath) {
               this.work.unsave = false;
               const timeout = setTimeout(() => {


### PR DESCRIPTION
### What is the purpose of the change
fix the problem which can not see and use saving method using hdfs for scripts

### Brief change log
- fix can not see and use saving while using hdfs for scripts.

### Verifying this change
This change is a trivial rework / code cleanup without any test coverage.  

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): no
- Anything that affects deployment: no
- The Core framework, i.e., AppConn, Orchestrator, ApiService.: no

### Documentation
- Does this pull request introduce a new feature?  no