### PR TITLE
fixbug：assembly打包的时候 dss-data-api-server和dss-data-governance-server模块…

### DIFF
--- a/assembly/dss-package/src/main/assembly/distribution.xml
+++ b/assembly/dss-package/src/main/assembly/distribution.xml
@@ -287,7 +287,7 @@
     <!--dss-data-api-server-->
     <fileSet>
       <directory>
-        ${basedir}/../../dss-data-api/dss-data-api-server/target/out/dss-data-api-server/lib/
+        ${basedir}/../../dss-apps/dss-data-api/dss-data-api-server/target/out/dss-data-api-server/lib/
       </directory>
       <outputDirectory>lib/dss-data-api/dss-data-api-server</outputDirectory>
       <includes>
@@ -298,7 +298,7 @@
     <!--dss-data-governance-server-->
     <fileSet>
       <directory>
-        ${basedir}/../../dss-data-governance/dss-data-governance-server/target/out/dss-data-governance-server/lib/
+        ${basedir}/../../dss-apps/dss-data-governance/dss-data-governance-server/target/out/dss-data-governance-server/lib/
       </directory>
       <outputDirectory>lib/dss-data-governance/dss-data-governance-server</outputDirectory>
       <includes>


### PR DESCRIPTION
…地址错误的问题

### What is the purpose of the change
fixbug for use maven install,when use assembly build moule dss-data-api-server and dss-data-governance-server, not found dss-data-api-server and dss-data-governance-server 's lib in director.

### Brief change log
(for example:)
- Define the location in /Users/liuxiaopeng/git/DataSphereStudio/assembly/dss-package/src/main/assembly/distribution.xml;fix the fileSet

### Verifying this change
This change is already covered by existing tests, such as (please describe tests).  
- use maven clean install for test this case

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (yes)
- Anything that affects deployment: (no)
- The Core framework, i.e., AppConn, Orchestrator, ApiService.: ( no)

### Documentation
- Does this pull request introduce a new feature? (no)
