### PR TITLE
fixbug:解决复制flow后发布到调度平台失败的问题

### DIFF
--- a/dss-framework/dss-framework-orchestrator-server/src/main/java/com/webank/wedatasphere/dss/orchestrator/server/service/OrchestratorService.java
+++ b/dss-framework/dss-framework-orchestrator-server/src/main/java/com/webank/wedatasphere/dss/orchestrator/server/service/OrchestratorService.java
@@ -70,6 +70,18 @@ public interface OrchestratorService {
                             String projectName,
                             Long orchestratorInfoId,
                             List<DSSLabel> dssLabels) throws Exception;
+    /**
+     * 复制编排
+     *
+     */
+    OrchestratorVo copyOrchestrator(String userName,
+                                    Workspace workspace,
+                                    String projectName,
+                                    Long projectId,
+                                    String description,
+                                    DSSOrchestratorInfo dssOrchestratorInfo,
+                                    List<DSSLabel> dssLabels) throws Exception;
+
 
     /**
      * 解锁编排对应的工作流

--- a/dss-framework/dss-framework-orchestrator-server/src/main/java/com/webank/wedatasphere/dss/orchestrator/server/service/impl/OrchestratorFrameworkServiceImpl.java
+++ b/dss-framework/dss-framework-orchestrator-server/src/main/java/com/webank/wedatasphere/dss/orchestrator/server/service/impl/OrchestratorFrameworkServiceImpl.java
@@ -177,7 +177,7 @@ public class OrchestratorFrameworkServiceImpl implements OrchestratorFrameworkSe
         return commonOrchestratorVo;
     }
 
-    private <K extends StructureRequestRef, V extends ResponseRef> V tryOrchestrationOperation(List<DSSLabel> dssLabels, Boolean askProjectSender, String userName, String projectName,
+    public <K extends StructureRequestRef, V extends ResponseRef> V tryOrchestrationOperation(List<DSSLabel> dssLabels, Boolean askProjectSender, String userName, String projectName,
                                                                                                Workspace workspace, DSSOrchestratorInfo dssOrchestrator,
                                                                                                Function<OrchestrationService, StructureOperation> getOrchestrationOperation,
                                                                                                BiFunction<StructureOperation, K, V> responseRefConsumer, String operationName) {

--- a/dss-framework/dss-framework-orchestrator-server/src/main/java/com/webank/wedatasphere/dss/orchestrator/server/service/impl/OrchestratorServiceImpl.java
+++ b/dss-framework/dss-framework-orchestrator-server/src/main/java/com/webank/wedatasphere/dss/orchestrator/server/service/impl/OrchestratorServiceImpl.java
@@ -239,6 +239,47 @@ public class OrchestratorServiceImpl implements OrchestratorService {
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
+    public OrchestratorVo copyOrchestrator(String userName,
+                                           Workspace workspace,
+                                           String projectName,
+                                           Long projectId,
+                                           String description,
+                                           DSSOrchestratorInfo dssOrchestratorInfo,
+                                           List<DSSLabel> dssLabels) throws Exception {
+        OrchestratorVo orchestratorVo = new OrchestratorVo();
+        //todo 增加校验
+        String uuid = UUID.randomUUID().toString();
+
+        //作为Orchestrator的唯一标识，包括跨环境导入导出也不发生变化。
+        dssOrchestratorInfo.setUUID(uuid);
+
+        String version = OrchestratorUtils.generateNewVersion();
+        String contextId = contextService.createContextID(workspace.getWorkspaceName(), projectName, dssOrchestratorInfo.getName(), version, userName);
+        LOGGER.info("Create a new ContextId: {} for new orchestrator {}.", contextId, dssOrchestratorInfo.getName());
+        //1. 访问DSS工作流微模块创建工作流
+        RefJobContentResponseRef appRef = tryRefOperation(dssOrchestratorInfo, userName, workspace, dssLabels, null,
+                developmentService -> ((RefCRUDService) developmentService).getRefCreationOperation(),
+                dssContextRequestRef -> dssContextRequestRef.setContextId(contextId),
+                projectRefRequestRef -> projectRefRequestRef.setProjectName(projectName).setRefProjectId(projectId),
+                (developmentOperation, developmentRequestRef) -> {
+                    DSSOrchestrator dssOrchestrator = orchestratorManager.getOrCreateOrchestrator(userName,
+                            workspace.getWorkspaceName(), dssOrchestratorInfo.getType(), dssLabels);
+                    Map<String, Object> dssJobContent = MapUtils.newCommonMapBuilder()
+                            .put(OrchestratorRefConstant.DSS_ORCHESTRATOR_INFO_KEY, dssOrchestratorInfo)
+                            .put(OrchestratorRefConstant.ORCHESTRATOR_VERSION_KEY, version)
+                            .put(OrchestratorRefConstant.ORCHESTRATION_SCHEDULER_APP_CONN, Optional.ofNullable(dssOrchestrator)
+                                    .map(DSSOrchestrator::getSchedulerAppConn).map(AppConn::getAppDesc).map(AppDesc::getAppName)
+                                    .map(Object::toString).orElse("NULL")).build();
+                    DSSJobContentRequestRef requestRef = (DSSJobContentRequestRef) developmentRequestRef;
+                    requestRef.setDSSJobContent(dssJobContent);
+                    return ((RefCreationOperation) developmentOperation).createRef(requestRef);
+                }, "create");
+
+        return orchestratorVo;
+    }
+
+    @Override
     public OrchestratorUnlockVo unlockOrchestrator(String userName,
                                                    Workspace workspace,
                                                    String projectName,


### PR DESCRIPTION
### What is the purpose of the change
目前存在bug，复制flow后，发布复制的新的flow，然后报发布失败。在复制流程中增加了与下层平台交互，并持久化关联信息的逻辑

### Brief change log
- 在OrchestratorCopyJob中的run方法中增加了逻辑
- 在OrchestratorService接口中增加了copyOrchestrator方法并在OrchestratorServiceImpl中实现了它
- 将OrchestratorFrameworkServiceImpl中的tryOrchestrationOperation从private变成public

### Verifying this change
代码经过了以上流程的测试

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): no
- Anything that affects deployment: no
- The Core framework, i.e., AppConn, Orchestrator, ApiService.: no

### Documentation
- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)